### PR TITLE
add PHP application template

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,7 +34,7 @@ jobs:
           node-version: current
 
       - name: Install Cartesi CLI
-        run: npm install -g @cartesi/cli@2.0.0-alpha.8
+        run: npm install -g @cartesi/cli@2.0.0-alpha.16
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,6 +20,7 @@ jobs:
           - java
           - javascript
           - lua
+          - php
           - python
           - ruby
           - rust

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,3 +45,13 @@ jobs:
       - name: Build ${{ matrix.template }}
         run: cartesi build
         working-directory: ${{ matrix.template }}
+
+      - name: Print cartesi-machine hash
+        run: cartesi hash
+        working-directory: ${{ matrix.template }}
+
+      - name: Upload root.ext2 artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.template }}-root.ext2
+          path: ${{ matrix.template }}/.cartesi/root.ext2

--- a/cpp-low-level/Dockerfile
+++ b/cpp-low-level/Dockerfile
@@ -1,27 +1,64 @@
 # syntax=docker.io/docker/dockerfile:1
-ARG MACHINE_GUEST_TOOLS_VERSION=0.17.1
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG UBUNTU_TAG=noble-20250529
-ARG APT_UPDATE_SNAPSHOT=20250601T030400Z
+ARG APT_UPDATE_SNAPSHOT=20250811T210202Z
+ARG DEBIAN_TAG=trixie-20250811-slim@sha256:c85a2732e97694ea77237c61304b3bb410e0e961dd6ee945997a06c788c545bb
+ARG MACHINE_GUEST_TOOLS_VERSION=0.17.1
+
+FROM scratch AS machine-guest-tools-checksum
+COPY <<EOF /tmp/machine-guest-tools_riscv64.deb.sha512sum
+96625d97354c1cc905a8630f3d715f64b14bc5b89f3e30913d2eb02da3a01f20a7784d32c2ed340ca401dce4d1bc0e6bebfc3fbb3808725225c5793b16fa6ef4 /tmp/machine-guest-tools_riscv64.deb
+EOF
+
+# Configure apt to use snapshot.debian.org
+FROM scratch AS apt-config
+ARG APT_UPDATE_SNAPSHOT
+COPY <<EOF /etc/apt/sources.list.d/debian.sources
+Types: deb
+URIs: http://snapshot.debian.org/archive/debian/${APT_UPDATE_SNAPSHOT}
+Suites: trixie trixie-updates
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+
+Types: deb
+URIs: http://snapshot.debian.org/archive/debian-security/${APT_UPDATE_SNAPSHOT}
+Suites: trixie-security
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+EOF
+
+# Configure apt to accept snapshots for expired suites (security, updates)
+COPY <<EOF /etc/apt/apt.conf.d/10-nocheckvalid
+Acquire::Check-Valid-Until false;
+EOF
+
+# Configure apt to Ignore TLS verify on first apt-get update --snapshot=
+COPY <<EOF /etc/apt/apt.conf.d/99-insecure
+Acquire::https::Verify-Peer false;
+Acquire::https::Verify-Host false;
+EOF
+
 
 ################################################################################
 # riscv64 base stage
-FROM --platform=linux/riscv64 ubuntu:${UBUNTU_TAG} AS base
+FROM --platform=linux/riscv64 debian:${DEBIAN_TAG} AS base
 
-ARG APT_UPDATE_SNAPSHOT
+COPY --link --from=apt-config / /
+
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
-set -eu
+set -e
+
 apt-get update
-apt-get install -y --no-install-recommends ca-certificates curl
-apt-get update --snapshot=${APT_UPDATE_SNAPSHOT}
+apt-get install -y --no-install-recommends \
+    ca-certificates
 EOF
 
 ################################################################################
 # riscv64 builder stage
 FROM base AS builder
+RUN rm /etc/apt/apt.conf.d/99-insecure
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
@@ -33,19 +70,25 @@ apt-get install -y --no-install-recommends \
   busybox-static \
   libtool \
   pkg-config
-rm -rf /var/lib/apt/lists/*
 EOF
 
-ARG MACHINE_GUEST_TOOLS_VERSION
-ADD https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb  /tmp/machine-guest-tools_riscv64.deb
+COPY --link --from=machine-guest-tools-checksum / /
 
+ARG MACHINE_GUEST_TOOLS_VERSION
 RUN <<EOF
-set -e
-echo "96625d97354c1cc905a8630f3d715f64b14bc5b89f3e30913d2eb02da3a01f20a7784d32c2ed340ca401dce4d1bc0e6bebfc3fbb3808725225c5793b16fa6ef4 /tmp/machine-guest-tools_riscv64.deb" \
-  | sha512sum -c
+set -eu
+
 apt-get install -y --no-install-recommends \
-  /tmp/machine-guest-tools_riscv64.deb
+    busybox-static
+
+cd /tmp
+busybox wget https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb
+sha512sum -c /tmp/machine-guest-tools_riscv64.deb.sha512sum
+apt-get install -y --no-install-recommends /tmp/machine-guest-tools_riscv64.deb
+
 rm /tmp/machine-guest-tools_riscv64.deb
+rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
+apt-get dist-clean
 EOF
 
 WORKDIR /opt/cartesi/dapp
@@ -55,23 +98,31 @@ RUN make
 ################################################################################
 # runtime stage: produces final image that will be executed
 FROM base
+RUN rm /etc/apt/apt.conf.d/99-insecure
+
+COPY --link --from=machine-guest-tools-checksum / /
 
 ARG MACHINE_GUEST_TOOLS_VERSION
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
-set -e
+set -eu
+
 apt-get install -y --no-install-recommends \
   busybox-static
 
 cd /tmp
 busybox wget https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb
-echo "96625d97354c1cc905a8630f3d715f64b14bc5b89f3e30913d2eb02da3a01f20a7784d32c2ed340ca401dce4d1bc0e6bebfc3fbb3808725225c5793b16fa6ef4 /tmp/machine-guest-tools_riscv64.deb" \
-  | sha512sum -c
-apt-get install -y --no-install-recommends \
-  /tmp/machine-guest-tools_riscv64.deb
+sha512sum -c /tmp/machine-guest-tools_riscv64.deb.sha512sum
+
+apt-get install -y --no-install-recommends /tmp/machine-guest-tools_riscv64.deb
 rm /tmp/machine-guest-tools_riscv64.deb
 
+# Fix non-determinism issue when installing machine-guest-tools
+cp -a /etc/shadow /etc/shadow-
+
+# Strip non-determinism
 rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
+apt-get dist-clean
 EOF
 
 ENV PATH="/opt/cartesi/bin:${PATH}"

--- a/cpp/Dockerfile
+++ b/cpp/Dockerfile
@@ -2,25 +2,56 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG UBUNTU_TAG=noble-20250529
-ARG APT_UPDATE_SNAPSHOT=20250601T030400Z
+ARG DEBIAN_TAG=trixie-20250811-slim@sha256:c85a2732e97694ea77237c61304b3bb410e0e961dd6ee945997a06c788c545bb
+ARG APT_UPDATE_SNAPSHOT=20250811T210202Z
+
+# Configure apt to use snapshot.debian.org
+FROM scratch AS apt-config
+ARG APT_UPDATE_SNAPSHOT
+COPY <<EOF /etc/apt/sources.list.d/debian.sources
+Types: deb
+URIs: http://snapshot.debian.org/archive/debian/${APT_UPDATE_SNAPSHOT}
+Suites: trixie trixie-updates
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+
+Types: deb
+URIs: http://snapshot.debian.org/archive/debian-security/${APT_UPDATE_SNAPSHOT}
+Suites: trixie-security
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+EOF
+
+# Configure apt to accept snapshots for expired suites (security, updates)
+COPY <<EOF /etc/apt/apt.conf.d/10-nocheckvalid
+Acquire::Check-Valid-Until false;
+EOF
+
+# Configure apt to Ignore TLS verify on first apt-get update --snapshot=
+COPY <<EOF /etc/apt/apt.conf.d/99-insecure
+Acquire::https::Verify-Peer false;
+Acquire::https::Verify-Host false;
+EOF
 
 ################################################################################
 # riscv64 base stage
-FROM --platform=linux/riscv64 ubuntu:${UBUNTU_TAG} AS base
+FROM --platform=linux/riscv64 debian:${DEBIAN_TAG} AS base
 
-ARG APT_UPDATE_SNAPSHOT
+COPY --link --from=apt-config / /
+
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
-set -eu
+set -e
+
 apt-get update
-apt-get install -y --no-install-recommends ca-certificates curl
-apt-get update --snapshot=${APT_UPDATE_SNAPSHOT}
+apt-get install -y --no-install-recommends \
+    ca-certificates
 EOF
 
 ################################################################################
 # riscv64 builder stage
 FROM base AS builder
+RUN rm /etc/apt/apt.conf.d/99-insecure
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
@@ -29,8 +60,8 @@ apt-get install -y --no-install-recommends \
   autoconf \
   automake \
   build-essential \
+  curl \
   libtool
-rm -rf /var/lib/apt/lists/*
 EOF
 
 WORKDIR /opt/cartesi/dapp
@@ -40,23 +71,33 @@ RUN make
 ################################################################################
 # runtime stage: produces final image that will be executed
 FROM base
+RUN rm /etc/apt/apt.conf.d/99-insecure
+
+COPY <<EOF /tmp/machine-guest-tools_riscv64.deb.sha512sum
+96625d97354c1cc905a8630f3d715f64b14bc5b89f3e30913d2eb02da3a01f20a7784d32c2ed340ca401dce4d1bc0e6bebfc3fbb3808725225c5793b16fa6ef4 /tmp/machine-guest-tools_riscv64.deb
+EOF
 
 ARG MACHINE_GUEST_TOOLS_VERSION=0.17.1
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
-set -e
+set -eu
+
 apt-get install -y --no-install-recommends \
   busybox-static
 
 cd /tmp
 busybox wget https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb
-echo "96625d97354c1cc905a8630f3d715f64b14bc5b89f3e30913d2eb02da3a01f20a7784d32c2ed340ca401dce4d1bc0e6bebfc3fbb3808725225c5793b16fa6ef4 /tmp/machine-guest-tools_riscv64.deb" \
-  | sha512sum -c
-apt-get install -y --no-install-recommends \
-  /tmp/machine-guest-tools_riscv64.deb
+sha512sum -c /tmp/machine-guest-tools_riscv64.deb.sha512sum
+
+apt-get install -y --no-install-recommends /tmp/machine-guest-tools_riscv64.deb
 rm /tmp/machine-guest-tools_riscv64.deb
 
+# Fix non-determinism issue when installing machine-guest-tools
+cp -a /etc/shadow /etc/shadow-
+
+# Strip non-determinism
 rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
+apt-get dist-clean
 EOF
 
 ENV PATH="/opt/cartesi/bin:${PATH}"

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -2,54 +2,67 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG UBUNTU_TAG=noble-20250529
-ARG APT_UPDATE_SNAPSHOT=20250601T030400Z
+ARG APT_UPDATE_SNAPSHOT=20250811T210202Z
+ARG DEBIAN_TAG=trixie-20250811-slim@sha256:c85a2732e97694ea77237c61304b3bb410e0e961dd6ee945997a06c788c545bb
+ARG GO_VERSION=1.24.6
+
+# Configure apt to use snapshot.debian.org
+FROM scratch AS apt-config
+ARG APT_UPDATE_SNAPSHOT
+COPY <<EOF /etc/apt/sources.list.d/debian.sources
+Types: deb
+URIs: http://snapshot.debian.org/archive/debian/${APT_UPDATE_SNAPSHOT}
+Suites: trixie trixie-updates
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+
+Types: deb
+URIs: http://snapshot.debian.org/archive/debian-security/${APT_UPDATE_SNAPSHOT}
+Suites: trixie-security
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+EOF
+
+# Configure apt to accept snapshots for expired suites (security, updates)
+COPY <<EOF /etc/apt/apt.conf.d/10-nocheckvalid
+Acquire::Check-Valid-Until false;
+EOF
+
+# Configure apt to Ignore TLS verify on first apt-get update --snapshot=
+COPY <<EOF /etc/apt/apt.conf.d/99-insecure
+Acquire::https::Verify-Peer false;
+Acquire::https::Verify-Host false;
+EOF
 
 ################################################################################
 # riscv64 base stage
-FROM --platform=linux/riscv64 ubuntu:${UBUNTU_TAG} AS base-riscv64
+FROM --platform=linux/riscv64 debian:${DEBIAN_TAG} AS base
 
-ARG APT_UPDATE_SNAPSHOT
-ARG DEBIAN_FRONTEND=noninteractive
-RUN <<EOF
-set -eu
-apt-get update
-apt-get install -y --no-install-recommends ca-certificates curl
-apt-get update --snapshot=${APT_UPDATE_SNAPSHOT}
-EOF
-
-################################################################################
-# cross base stage
-FROM --platform=$BUILDPLATFORM ubuntu:${UBUNTU_TAG} AS base-cross
-
-ARG APT_UPDATE_SNAPSHOT
-ARG DEBIAN_FRONTEND=noninteractive
-RUN <<EOF
-set -eu
-apt-get update
-apt-get install -y --no-install-recommends ca-certificates curl
-apt-get update --snapshot=${APT_UPDATE_SNAPSHOT}
-EOF
-
-################################################################################
-# cross build stage
-FROM base-cross AS cross-build-stage
+COPY --link --from=apt-config / /
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
+
+apt-get update
 apt-get install -y --no-install-recommends \
-    build-essential \
-    ca-certificates \
-    g++-riscv64-linux-gnu
+    ca-certificates
 EOF
 
-ARG GOVERSION=1.23.2
+################################################################################
+# golang cross build stage
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-trixie AS cross-builder
 
-WORKDIR /opt/build
+COPY --link --from=apt-config / /
 
-RUN curl -fsSL https://go.dev/dl/go${GOVERSION}.linux-$(dpkg --print-architecture).tar.gz | \
-  tar -C /usr/local -xzf -
+ARG DEBIAN_FRONTEND=noninteractive
+RUN <<EOF
+set -eu
+apt-get update
+apt-get install -y --no-install-recommends \
+    build-essential \
+    g++-riscv64-linux-gnu
+EOF
 
 ENV GOOS=linux
 ENV GOARCH=riscv64
@@ -57,36 +70,47 @@ ENV CGO_ENABLED=1
 ENV CC=riscv64-linux-gnu-gcc
 ENV PATH=/usr/local/go/bin:${PATH}
 
+WORKDIR /opt/cartesi/dapp
 COPY src .
-
 RUN make
 
 ################################################################################
 # runtime stage: produces final image that will be executed
-FROM base-riscv64
+FROM base
+RUN rm /etc/apt/apt.conf.d/99-insecure
+
+COPY <<EOF /tmp/machine-guest-tools_riscv64.deb.sha512sum
+96625d97354c1cc905a8630f3d715f64b14bc5b89f3e30913d2eb02da3a01f20a7784d32c2ed340ca401dce4d1bc0e6bebfc3fbb3808725225c5793b16fa6ef4 /tmp/machine-guest-tools_riscv64.deb
+EOF
 
 ARG MACHINE_GUEST_TOOLS_VERSION=0.17.1
 ARG DEBIAN_FRONTEND=noninteractive
+
 RUN <<EOF
-set -e
+set -eu
+
 apt-get install -y --no-install-recommends \
   busybox-static
 
 cd /tmp
 busybox wget https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb
-echo "96625d97354c1cc905a8630f3d715f64b14bc5b89f3e30913d2eb02da3a01f20a7784d32c2ed340ca401dce4d1bc0e6bebfc3fbb3808725225c5793b16fa6ef4 /tmp/machine-guest-tools_riscv64.deb" \
-  | sha512sum -c
-apt-get install -y --no-install-recommends \
-  /tmp/machine-guest-tools_riscv64.deb
+sha512sum -c /tmp/machine-guest-tools_riscv64.deb.sha512sum
+
+apt-get install -y --no-install-recommends /tmp/machine-guest-tools_riscv64.deb
 rm /tmp/machine-guest-tools_riscv64.deb
 
+# Fix non-determinism issue when installing machine-guest-tools
+cp -a /etc/shadow /etc/shadow-
+
+# Strip non-determinism
 rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
+apt-get dist-clean
 EOF
 
 ENV PATH="/opt/cartesi/bin:${PATH}"
 
 WORKDIR /opt/cartesi/dapp
-COPY --from=cross-build-stage /opt/build/dapp .
+COPY --from=cross-builder /opt/cartesi/dapp/dapp .
 
 ENV ROLLUP_HTTP_SERVER_URL="http://127.0.0.1:5004"
 

--- a/lua/Dockerfile
+++ b/lua/Dockerfile
@@ -2,25 +2,56 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG UBUNTU_TAG=noble-20250529
-ARG APT_UPDATE_SNAPSHOT=20250601T030400Z
+ARG DEBIAN_TAG=trixie-20250811-slim@sha256:c85a2732e97694ea77237c61304b3bb410e0e961dd6ee945997a06c788c545bb
+ARG APT_UPDATE_SNAPSHOT=20250811T210202Z
+
+# Configure apt to use snapshot.debian.org
+FROM scratch AS apt-config
+ARG APT_UPDATE_SNAPSHOT
+COPY <<EOF /etc/apt/sources.list.d/debian.sources
+Types: deb
+URIs: http://snapshot.debian.org/archive/debian/${APT_UPDATE_SNAPSHOT}
+Suites: trixie trixie-updates
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+
+Types: deb
+URIs: http://snapshot.debian.org/archive/debian-security/${APT_UPDATE_SNAPSHOT}
+Suites: trixie-security
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+EOF
+
+# Configure apt to accept snapshots for expired suites (security, updates)
+COPY <<EOF /etc/apt/apt.conf.d/10-nocheckvalid
+Acquire::Check-Valid-Until false;
+EOF
+
+# Configure apt to Ignore TLS verify on first apt-get update --snapshot=
+COPY <<EOF /etc/apt/apt.conf.d/99-insecure
+Acquire::https::Verify-Peer false;
+Acquire::https::Verify-Host false;
+EOF
 
 ################################################################################
 # riscv64 base stage
-FROM --platform=linux/riscv64 ubuntu:${UBUNTU_TAG} AS base
+FROM --platform=linux/riscv64 debian:${DEBIAN_TAG} AS base
 
-ARG APT_UPDATE_SNAPSHOT
+COPY --link --from=apt-config / /
+
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
-set -eu
+set -e
+
 apt-get update
-apt-get install -y --no-install-recommends ca-certificates
-apt-get update --snapshot=${APT_UPDATE_SNAPSHOT}
+apt-get install -y --no-install-recommends \
+    ca-certificates
 EOF
 
 ################################################################################
 # riscv64 builder stage
 FROM base AS builder
+RUN rm /etc/apt/apt.conf.d/99-insecure
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
@@ -30,7 +61,6 @@ apt-get install -y --no-install-recommends \
   liblua5.4-dev \
   lua5.4 \
   luarocks
-rm -rf /var/lib/apt/lists/*
 
 luarocks install --lua-version=5.4 luasocket 3.1.0-1
 luarocks install --lua-version=5.4 dkjson 2.6-1
@@ -39,31 +69,46 @@ EOF
 ################################################################################
 # riscv64 final stage
 FROM base
+RUN rm /etc/apt/apt.conf.d/99-insecure
+
+COPY <<EOF /tmp/machine-guest-tools_riscv64.deb.sha512sum
+96625d97354c1cc905a8630f3d715f64b14bc5b89f3e30913d2eb02da3a01f20a7784d32c2ed340ca401dce4d1bc0e6bebfc3fbb3808725225c5793b16fa6ef4 /tmp/machine-guest-tools_riscv64.deb
+EOF
 
 ARG MACHINE_GUEST_TOOLS_VERSION=0.17.1
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
-set -e
+set -eu
+
 apt-get install -y --no-install-recommends \
-  busybox-static \
-  liblua5.4-dev \
-  lua5.4
+  busybox-static
 
 cd /tmp
 busybox wget https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb
-echo "96625d97354c1cc905a8630f3d715f64b14bc5b89f3e30913d2eb02da3a01f20a7784d32c2ed340ca401dce4d1bc0e6bebfc3fbb3808725225c5793b16fa6ef4 /tmp/machine-guest-tools_riscv64.deb" \
-  | sha512sum -c
-apt-get install -y --no-install-recommends \
-  /tmp/machine-guest-tools_riscv64.deb
+sha512sum -c /tmp/machine-guest-tools_riscv64.deb.sha512sum
+
+apt-get install -y --no-install-recommends /tmp/machine-guest-tools_riscv64.deb
 rm /tmp/machine-guest-tools_riscv64.deb
 
+# Fix non-determinism issue when installing machine-guest-tools
+cp -a /etc/shadow /etc/shadow-
+EOF
+
+RUN <<EOF
+set -e
+apt-get install -y --no-install-recommends \
+  liblua5.4-dev \
+  lua5.4
+
+# Strip non-determinism
 rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
+apt-get dist-clean
 EOF
 
 COPY --from=builder /usr/local/lib/lua /usr/local/lib/lua
 COPY --from=builder /usr/local/share/lua /usr/local/share/lua
 
-ENV PATH="/opt/cartesi/bin:/opt/cartesi/dapp:${PATH}"
+ENV PATH="/opt/cartesi/bin:${PATH}"
 
 WORKDIR /opt/cartesi/dapp
 COPY . .

--- a/php/.dockerignore
+++ b/php/.dockerignore
@@ -1,0 +1,2 @@
+.cartesi
+vendor

--- a/php/.gitignore
+++ b/php/.gitignore
@@ -1,0 +1,2 @@
+.cartesi
+vendor

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -1,0 +1,118 @@
+# syntax=docker.io/docker/dockerfile:1
+
+# This enforces that the packages downloaded from the repositories are the same
+# for the defined date, no matter when the image is built.
+ARG APT_UPDATE_SNAPSHOT=20250811T210202Z
+ARG PHP_VERSION=8.4.11
+
+# Configure apt to use snapshot.debian.org
+FROM scratch AS apt-config
+ARG APT_UPDATE_SNAPSHOT
+COPY <<EOF /etc/apt/sources.list.d/debian.sources
+Types: deb
+URIs: http://snapshot.debian.org/archive/debian/${APT_UPDATE_SNAPSHOT}
+Suites: trixie trixie-updates
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+
+Types: deb
+URIs: http://snapshot.debian.org/archive/debian-security/${APT_UPDATE_SNAPSHOT}
+Suites: trixie-security
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+EOF
+
+# Configure apt to accept snapshots for expired suites (security, updates)
+COPY <<EOF /etc/apt/apt.conf.d/10-nocheckvalid
+Acquire::Check-Valid-Until false;
+EOF
+
+# Configure apt to Ignore TLS verify on first apt-get update --snapshot=
+COPY <<EOF /etc/apt/apt.conf.d/99-insecure
+Acquire::https::Verify-Peer false;
+Acquire::https::Verify-Host false;
+EOF
+
+################################################################################
+# riscv64 base stage
+FROM --platform=linux/riscv64 php:${PHP_VERSION}-trixie@sha256:22dfaf12390946424b932c67f3f949268511e6a834f788f4e8a6fa34fb12d1c4 AS base
+
+COPY --link --from=apt-config / /
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN <<EOF
+set -e
+
+apt-get update
+apt-get install -y --no-install-recommends \
+    ca-certificates
+EOF
+
+################################################################################
+# riscv64 builder stage
+FROM base AS builder
+RUN rm /etc/apt/apt.conf.d/99-insecure
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN <<EOF
+set -e
+apt-get update
+apt-get install -y --no-install-recommends \
+  curl \
+  git \
+  unzip
+EOF
+
+# Install composer from container registry
+# https://getcomposer.org/doc/00-intro.md#docker-image
+COPY --from=composer/composer:2.8.11-bin@sha256:abd63db39eb2565a5af2bece27befd9bdf1041938b5caf200852f3458b8b3592 \
+  /composer /usr/bin/composer
+
+WORKDIR /opt/cartesi/dapp
+COPY composer.json composer.lock ./
+RUN composer install
+
+################################################################################
+# runtime stage: produces final image that will be executed
+FROM base
+RUN rm /etc/apt/apt.conf.d/99-insecure
+
+COPY <<EOF /tmp/machine-guest-tools_riscv64.deb.sha512sum
+96625d97354c1cc905a8630f3d715f64b14bc5b89f3e30913d2eb02da3a01f20a7784d32c2ed340ca401dce4d1bc0e6bebfc3fbb3808725225c5793b16fa6ef4 /tmp/machine-guest-tools_riscv64.deb
+EOF
+
+ARG MACHINE_GUEST_TOOLS_VERSION=0.17.1
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN <<EOF
+set -eu
+
+apt-get install -y --no-install-recommends \
+  busybox-static
+
+cd /tmp
+busybox wget https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb
+sha512sum -c /tmp/machine-guest-tools_riscv64.deb.sha512sum
+
+apt-get install -y --no-install-recommends /tmp/machine-guest-tools_riscv64.deb
+rm /tmp/machine-guest-tools_riscv64.deb
+
+# Fix non-determinism issue when installing machine-guest-tools
+cp -a /etc/shadow /etc/shadow-
+
+# Strip non-determinism
+rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
+apt-get dist-clean
+EOF
+
+ENV PATH="/opt/cartesi/bin:${PATH}"
+
+COPY --from=builder /opt/cartesi/dapp/vendor /opt/cartesi/dapp/vendor
+
+WORKDIR /opt/cartesi/dapp
+COPY index.php .
+
+ENV ROLLUP_HTTP_SERVER_URL="http://127.0.0.1:5004"
+
+ENTRYPOINT ["rollup-init"]
+CMD ["php", "index.php"]

--- a/php/composer.json
+++ b/php/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "guzzlehttp/guzzle": "^7.0"
+    }
+}

--- a/php/composer.lock
+++ b/php/composer.lock
@@ -1,0 +1,615 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "045658d81f6d9d3243e731dda7bf04d1",
+    "packages": [
+        {
+            "name": "guzzlehttp/guzzle",
+            "version": "7.9.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "d281ed313b989f213357e3be1a179f02196ac99b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/d281ed313b989f213357e3be1a179f02196ac99b",
+                "reference": "d281ed313b989f213357e3be1a179f02196ac99b",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "guzzlehttp/promises": "^1.5.3 || ^2.0.3",
+                "guzzlehttp/psr7": "^2.7.0",
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-client": "^1.0",
+                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+            },
+            "provide": {
+                "psr/http-client-implementation": "1.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "ext-curl": "*",
+                "guzzle/client-integration-tests": "3.0.2",
+                "php-http/message-factory": "^1.1",
+                "phpunit/phpunit": "^8.5.39 || ^9.6.20",
+                "psr/log": "^1.1 || ^2.0 || ^3.0"
+            },
+            "suggest": {
+                "ext-curl": "Required for CURL handler support",
+                "ext-intl": "Required for Internationalized Domain Name (IDN) support",
+                "psr/log": "Required for using the Log middleware"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Jeremy Lindblom",
+                    "email": "jeremeamia@gmail.com",
+                    "homepage": "https://github.com/jeremeamia"
+                },
+                {
+                    "name": "George Mponos",
+                    "email": "gmponos@gmail.com",
+                    "homepage": "https://github.com/gmponos"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://github.com/sagikazarmark"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "psr-18",
+                "psr-7",
+                "rest",
+                "web service"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/guzzle/issues",
+                "source": "https://github.com/guzzle/guzzle/tree/7.9.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/guzzle",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-07-24T11:22:20+00:00"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "6ea8dd08867a2a42619d65c3deb2c0fcbf81c8f8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/6ea8dd08867a2a42619d65c3deb2c0fcbf81c8f8",
+                "reference": "6ea8dd08867a2a42619d65c3deb2c0fcbf81c8f8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "phpunit/phpunit": "^8.5.39 || ^9.6.20"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/promises/issues",
+                "source": "https://github.com/guzzle/promises/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/promises",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-07-18T10:29:17+00:00"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "2.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "a70f5c95fb43bc83f07c9c948baa0dc1829bf201"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/a70f5c95fb43bc83f07c9c948baa0dc1829bf201",
+                "reference": "a70f5c95fb43bc83f07c9c948baa0dc1829bf201",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.1 || ^2.0",
+                "ralouphie/getallheaders": "^3.0"
+            },
+            "provide": {
+                "psr/http-factory-implementation": "1.0",
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "http-interop/http-factory-tests": "0.9.0",
+                "phpunit/phpunit": "^8.5.39 || ^9.6.20"
+            },
+            "suggest": {
+                "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "George Mponos",
+                    "email": "gmponos@gmail.com",
+                    "homepage": "https://github.com/gmponos"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://github.com/sagikazarmark"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://sagikazarmark.hu"
+                }
+            ],
+            "description": "PSR-7 message implementation that also provides common utility methods",
+            "keywords": [
+                "http",
+                "message",
+                "psr-7",
+                "request",
+                "response",
+                "stream",
+                "uri",
+                "url"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/psr7/issues",
+                "source": "https://github.com/guzzle/psr7/tree/2.7.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/psr7",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-07-18T11:15:46+00:00"
+        },
+        {
+            "name": "psr/http-client",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-client"
+            },
+            "time": "2023-09-23T14:17:50+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory"
+            },
+            "time": "2024-04-15T12:06:14+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/2.0"
+            },
+            "time": "2023-04-04T09:54:51+00:00"
+        },
+        {
+            "name": "ralouphie/getallheaders",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ralouphie/getallheaders.git",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^5 || ^6.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/getallheaders.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ralph Khattar",
+                    "email": "ralph.khattar@gmail.com"
+                }
+            ],
+            "description": "A polyfill for getallheaders.",
+            "support": {
+                "issues": "https://github.com/ralouphie/getallheaders/issues",
+                "source": "https://github.com/ralouphie/getallheaders/tree/develop"
+            },
+            "time": "2019-03-08T08:55:37+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "0e0d29ce1f20deffb4ab1b016a7257c4f1e789a1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/0e0d29ce1f20deffb4ab1b016a7257c4f1e789a1",
+                "reference": "0e0d29ce1f20deffb4ab1b016a7257c4f1e789a1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.5-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-04-18T09:32:20+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "2.6.0"
+}

--- a/php/index.php
+++ b/php/index.php
@@ -1,0 +1,52 @@
+#!/usr/bin/env php
+
+<?php
+
+require 'vendor/autoload.php';
+
+use GuzzleHttp\Client;
+
+$FINISH_PAYLOAD = ['status' => 'accept'];
+$ROLLUP_SERVER = getenv("ROLLUP_HTTP_SERVER_URL") ?: "http://127.0.0.1:5004";
+
+function handleAdvance($data) {
+    $payload = hex2bin(substr($data['payload'], 2));
+    error_log("Handling advance request for payload: $payload");
+    # TODO: add application logic here
+    return "accept";
+}
+
+function handleInspect($data) {
+    $payload = hex2bin(substr($data['payload'], 2));
+    error_log("Handling inspect request for payload: $payload");
+    # TODO: add application logic here
+    return "accept";
+}
+
+$client = new GuzzleHttp\Client(['base_uri' => $ROLLUP_SERVER]);
+
+while (true) {
+    error_log("Sending finish");
+
+    $response = $client->request('POST', '/finish', [
+        'json' => $FINISH_PAYLOAD
+    ]);
+
+    if ($response->getStatusCode() == 202) {
+        error_log("No pending rollup request, trying again");
+    } else {
+        $rollup_req = json_decode($response->getBody(), true);
+        $metadata = $rollup_req['data']['metadata'];
+
+        switch ($rollup_req['request_type']) {
+            case 'advance_state':
+                $finish['status'] = handleAdvance($rollup_req['data']);
+                break;
+            case 'inspect_state':
+                $finish['status'] = handleInspect($rollup_req['data']);
+                break;
+        }
+    }
+}
+
+?>

--- a/python/.dockerignore
+++ b/python/.dockerignore
@@ -1,0 +1,2 @@
+.cartesi
+.venv

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -2,61 +2,105 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG APT_UPDATE_SNAPSHOT=20250424T030400Z
+ARG APT_UPDATE_SNAPSHOT=20250811T210202Z
+ARG PYTHON_VERSION=3.13.6
 
-################################################################################
-# riscv64 base stage
-FROM --platform=linux/riscv64 cartesi/python:3.13.2-slim-noble AS base
-
+# Configure apt to use snapshot.debian.org
+FROM scratch AS apt-config
 ARG APT_UPDATE_SNAPSHOT
-ARG DEBIAN_FRONTEND=noninteractive
-RUN <<EOF
-set -eu
-apt-get update
-apt-get install -y --no-install-recommends ca-certificates curl
-apt-get update --snapshot=${APT_UPDATE_SNAPSHOT}
+COPY <<EOF /etc/apt/sources.list.d/debian.sources
+Types: deb
+URIs: http://snapshot.debian.org/archive/debian/${APT_UPDATE_SNAPSHOT}
+Suites: trixie trixie-updates
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+
+Types: deb
+URIs: http://snapshot.debian.org/archive/debian-security/${APT_UPDATE_SNAPSHOT}
+Suites: trixie-security
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+EOF
+
+# Configure apt to accept snapshots for expired suites (security, updates)
+COPY <<EOF /etc/apt/apt.conf.d/10-nocheckvalid
+Acquire::Check-Valid-Until false;
+EOF
+
+# Configure apt to Ignore TLS verify on first apt-get update --snapshot=
+COPY <<EOF /etc/apt/apt.conf.d/99-insecure
+Acquire::https::Verify-Peer false;
+Acquire::https::Verify-Host false;
 EOF
 
 ################################################################################
-# runtime stage: produces final image that will be executed
+# riscv64 base stage
+FROM --platform=linux/riscv64 python:${PYTHON_VERSION}-slim-trixie AS base
 
-# Here the image's platform MUST be linux/riscv64.
-# Give preference to small base images, which lead to better start-up
-# performance when loading the Cartesi Machine.
+COPY --link --from=apt-config / /
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN <<EOF
+set -e
+
+apt-get update
+apt-get install -y --no-install-recommends \
+    ca-certificates
+EOF
+
+################################################################################
+# riscv64 builder
+FROM base AS builder
+RUN rm /etc/apt/apt.conf.d/99-insecure
+
+WORKDIR /opt/cartesi/dapp
+RUN python -m venv /opt/cartesi/dapp/venv
+ENV PATH="/opt/cartesi/dapp/venv/bin:$PATH"
+
+COPY requirements.txt .
+RUN pip install -r requirements.txt --no-cache && \
+    find /usr/local/lib -type d -name __pycache__ -exec rm -r {} +
+
+################################################################################
+# runtime stage: produces final image that will be executed
 FROM base
+RUN rm /etc/apt/apt.conf.d/99-insecure
+
+COPY <<EOF /tmp/machine-guest-tools_riscv64.deb.sha512sum
+96625d97354c1cc905a8630f3d715f64b14bc5b89f3e30913d2eb02da3a01f20a7784d32c2ed340ca401dce4d1bc0e6bebfc3fbb3808725225c5793b16fa6ef4 /tmp/machine-guest-tools_riscv64.deb
+EOF
 
 ARG MACHINE_GUEST_TOOLS_VERSION=0.17.1
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
-set -e
+set -eu
+
 apt-get install -y --no-install-recommends \
-  busybox-static
+    busybox-static
 
 cd /tmp
 busybox wget https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb
-echo "96625d97354c1cc905a8630f3d715f64b14bc5b89f3e30913d2eb02da3a01f20a7784d32c2ed340ca401dce4d1bc0e6bebfc3fbb3808725225c5793b16fa6ef4 /tmp/machine-guest-tools_riscv64.deb" \
-  | sha512sum -c
-apt-get install -y --no-install-recommends \
-  /tmp/machine-guest-tools_riscv64.deb
+sha512sum -c /tmp/machine-guest-tools_riscv64.deb.sha512sum
+
+apt-get install -y --no-install-recommends /tmp/machine-guest-tools_riscv64.deb
 rm /tmp/machine-guest-tools_riscv64.deb
 
+# Fix non-determinism issue when installing machine-guest-tools
+cp -a /etc/shadow /etc/shadow-
+
+# Strip non-determinism
 rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
+apt-get dist-clean
 EOF
 
-ENV PATH="/opt/cartesi/bin:${PATH}"
+ENV PATH="/opt/cartesi/dapp/venv/bin:/opt/cartesi/bin:${PATH}"
 
 WORKDIR /opt/cartesi/dapp
-COPY ./requirements.txt .
-
-RUN <<EOF
-set -e
-pip install -r requirements.txt --no-cache
-find /usr/local/lib -type d -name __pycache__ -exec rm -r {} +
-EOF
-
-COPY ./dapp.py .
+COPY --from=builder /opt/cartesi/dapp/venv ./venv
+COPY dapp.py .
 
 ENV ROLLUP_HTTP_SERVER_URL="http://127.0.0.1:5004"
 
+USER dapp
 ENTRYPOINT ["rollup-init"]
 CMD ["python3", "dapp.py"]

--- a/ruby/.dockerignore
+++ b/ruby/.dockerignore
@@ -1,1 +1,2 @@
 .cartesi
+.bundle

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -2,37 +2,69 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG UBUNTU_TAG=noble-20250529
-ARG APT_UPDATE_SNAPSHOT=20250601T030400Z
+ARG APT_UPDATE_SNAPSHOT=20250811T210202Z
+ARG RUBY_VERSION=3.4.5
 
-################################################################################
-# riscv64 base stage
-FROM --platform=linux/riscv64 ubuntu:${UBUNTU_TAG} AS base
-
+# Configure apt to use snapshot.debian.org
+FROM scratch AS apt-config
 ARG APT_UPDATE_SNAPSHOT
-ARG DEBIAN_FRONTEND=noninteractive
-RUN <<EOF
-set -eu
-apt-get update
-apt-get install -y --no-install-recommends ca-certificates curl
-apt-get update --snapshot=${APT_UPDATE_SNAPSHOT}
+COPY <<EOF /etc/apt/sources.list.d/debian.sources
+Types: deb
+URIs: http://snapshot.debian.org/archive/debian/${APT_UPDATE_SNAPSHOT}
+Suites: trixie trixie-updates
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+
+Types: deb
+URIs: http://snapshot.debian.org/archive/debian-security/${APT_UPDATE_SNAPSHOT}
+Suites: trixie-security
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+EOF
+
+# Configure apt to accept snapshots for expired suites (security, updates)
+COPY <<EOF /etc/apt/apt.conf.d/10-nocheckvalid
+Acquire::Check-Valid-Until false;
+EOF
+
+# Configure apt to Ignore TLS verify on first apt-get update --snapshot=
+COPY <<EOF /etc/apt/apt.conf.d/99-insecure
+Acquire::https::Verify-Peer false;
+Acquire::https::Verify-Host false;
 EOF
 
 ################################################################################
-# riscv64 builder stage
+# riscv64 base stage
+FROM --platform=linux/riscv64 ruby:${RUBY_VERSION}-slim-trixie AS base
+
+COPY --link --from=apt-config / /
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN <<EOF
+set -e
+
+apt-get update
+apt-get install -y --no-install-recommends \
+    ca-certificates
+EOF
+
+################################################################################
+# builder stage
 FROM base AS builder
+RUN rm /etc/apt/apt.conf.d/99-insecure
+
+COPY --link --from=apt-config / /
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
 apt-get install -y --no-install-recommends \
-  build-essential \
-  ruby-dev \
-  ruby
-rm -rf /var/apt/lists/*
-gem install bundler --no-document
+  build-essential
 EOF
 
+RUN gem install bundler --no-document
+
+WORKDIR /opt/cartesi/dapp
 COPY Gemfile Gemfile.lock ./
 
 RUN <<EOF
@@ -44,32 +76,45 @@ EOF
 ################################################################################
 # runtime stage: produces final image that will be executed
 FROM base
+RUN rm /etc/apt/apt.conf.d/99-insecure
+
+COPY <<EOF /tmp/machine-guest-tools_riscv64.deb.sha512sum
+96625d97354c1cc905a8630f3d715f64b14bc5b89f3e30913d2eb02da3a01f20a7784d32c2ed340ca401dce4d1bc0e6bebfc3fbb3808725225c5793b16fa6ef4 /tmp/machine-guest-tools_riscv64.deb
+EOF
+
 ARG MACHINE_GUEST_TOOLS_VERSION=0.17.1
 ARG DEBIAN_FRONTEND=noninteractive
+
 RUN <<EOF
-set -e
+set -eu
+
 apt-get install -y --no-install-recommends \
-  busybox-static \
-  ruby
+  busybox-static
 
 cd /tmp
 busybox wget https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb
-echo "96625d97354c1cc905a8630f3d715f64b14bc5b89f3e30913d2eb02da3a01f20a7784d32c2ed340ca401dce4d1bc0e6bebfc3fbb3808725225c5793b16fa6ef4 /tmp/machine-guest-tools_riscv64.deb" \
-  | sha512sum -c
-apt-get install -y --no-install-recommends \
-  /tmp/machine-guest-tools_riscv64.deb
+sha512sum -c /tmp/machine-guest-tools_riscv64.deb.sha512sum
+
+apt-get install -y --no-install-recommends /tmp/machine-guest-tools_riscv64.deb
 rm /tmp/machine-guest-tools_riscv64.deb
 
+# Fix non-determinism issue when installing machine-guest-tools
+cp -a /etc/shadow /etc/shadow-
+
+# Strip non-determinism
 rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
+apt-get dist-clean
 EOF
 
 ENV PATH="/opt/cartesi/bin:${PATH}"
 
-# Copy over gems from the dependencies stage
-COPY --from=builder /var/lib/gems/ /var/lib/gems/
+# Copy over gems from the builder stage
+COPY --from=builder /usr/local/bundle /usr/local/bundle
 
-WORKDIR /usr/src/app
+WORKDIR /opt/cartesi/dapp
 COPY . .
+
+ENV ROLLUP_HTTP_SERVER_URL="http://127.0.0.1:5004"
 
 ENTRYPOINT ["rollup-init"]
 CMD ["ruby", "main.rb"]

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -2,106 +2,114 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG UBUNTU_TAG=noble-20250529
-ARG APT_UPDATE_SNAPSHOT=20250601T030400Z
+ARG APT_UPDATE_SNAPSHOT=20250811T210202Z
+ARG DEBIAN_TAG=trixie-20250811-slim@sha256:c85a2732e97694ea77237c61304b3bb410e0e961dd6ee945997a06c788c545bb
+ARG RUST_VERSION=1.89
 
-################################################################################
-# riscv64 base stage
-FROM --platform=linux/riscv64 ubuntu:${UBUNTU_TAG} AS base-riscv64
-
+# Configure apt to use snapshot.debian.org
+FROM scratch AS apt-config
 ARG APT_UPDATE_SNAPSHOT
-ARG DEBIAN_FRONTEND=noninteractive
-RUN <<EOF
-set -eu
-apt-get update
-apt-get install -y --no-install-recommends ca-certificates curl
-apt-get update --snapshot=${APT_UPDATE_SNAPSHOT}
+COPY <<EOF /etc/apt/sources.list.d/debian.sources
+Types: deb
+URIs: http://snapshot.debian.org/archive/debian/${APT_UPDATE_SNAPSHOT}
+Suites: trixie trixie-updates
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+
+Types: deb
+URIs: http://snapshot.debian.org/archive/debian-security/${APT_UPDATE_SNAPSHOT}
+Suites: trixie-security
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+EOF
+
+# Configure apt to accept snapshots for expired suites (security, updates)
+COPY <<EOF /etc/apt/apt.conf.d/10-nocheckvalid
+Acquire::Check-Valid-Until false;
+EOF
+
+# Configure apt to Ignore TLS verify on first apt-get update --snapshot=
+COPY <<EOF /etc/apt/apt.conf.d/99-insecure
+Acquire::https::Verify-Peer false;
+Acquire::https::Verify-Host false;
 EOF
 
 ################################################################################
-# cross base stage
-FROM --platform=$BUILDPLATFORM ubuntu:${UBUNTU_TAG} AS base-cross
+# riscv64 base stage
+FROM --platform=linux/riscv64 debian:${DEBIAN_TAG} AS base
 
-ARG APT_UPDATE_SNAPSHOT
+COPY --link --from=apt-config / /
+
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
-set -eu
+set -e
+
 apt-get update
-apt-get install -y --no-install-recommends ca-certificates curl
-apt-get update --snapshot=${APT_UPDATE_SNAPSHOT}
+apt-get install -y --no-install-recommends \
+    ca-certificates
 EOF
 
 ################################################################################
 # cross build stage
-FROM base-cross AS cross-build-stage
+FROM --platform=$BUILDPLATFORM rust:${RUST_VERSION}-slim-trixie AS cross-builder
 
-ENV RUSTUP_HOME=/usr/local/rustup \
-    CARGO_HOME=/usr/local/cargo \
-    PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.82.0
+COPY --link --from=apt-config / /
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
+apt-get update
 apt-get install -y --no-install-recommends \
     build-essential \
+    ca-certificates \
     g++-riscv64-linux-gnu
 EOF
 
-RUN <<EOF
-set -eux
-dpkgArch="$(dpkg --print-architecture)"
-case "${dpkgArch##*-}" in \
-    amd64) rustArch='x86_64-unknown-linux-gnu'; rustupSha256='6aeece6993e902708983b209d04c0d1dbb14ebb405ddb87def578d41f920f56d' ;;
-    armhf) rustArch='armv7-unknown-linux-gnueabihf'; rustupSha256='3c4114923305f1cd3b96ce3454e9e549ad4aa7c07c03aec73d1a785e98388bed' ;;
-    arm64) rustArch='aarch64-unknown-linux-gnu'; rustupSha256='1cffbf51e63e634c746f741de50649bbbcbd9dbe1de363c9ecef64e278dba2b2' ;;
-    i386) rustArch='i686-unknown-linux-gnu'; rustupSha256='0a6bed6e9f21192a51f83977716466895706059afb880500ff1d0e751ada5237' ;;
-    *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;;
-esac
-url="https://static.rust-lang.org/rustup/archive/1.27.1/${rustArch}/rustup-init"
-curl -fsSL -O "$url"
-echo "${rustupSha256} *rustup-init" | sha256sum -c -
-chmod +x rustup-init
-./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch}
-rm rustup-init
-chmod -R a+w $RUSTUP_HOME $CARGO_HOME
-rustup --version
-cargo --version
-rustc --version
-EOF
-
-RUN rustup target add riscv64gc-unknown-linux-gnu
-
 WORKDIR /opt/cartesi/dapp
 COPY . .
-RUN cargo build --release
+
+RUN <<EOF
+set -e
+rustup target add riscv64gc-unknown-linux-gnu
+cargo build --release
+EOF
 
 ################################################################################
 # runtime stage: produces final image that will be executed
-FROM base-riscv64
+FROM base
+RUN rm /etc/apt/apt.conf.d/99-insecure
+
+COPY <<EOF /tmp/machine-guest-tools_riscv64.deb.sha512sum
+96625d97354c1cc905a8630f3d715f64b14bc5b89f3e30913d2eb02da3a01f20a7784d32c2ed340ca401dce4d1bc0e6bebfc3fbb3808725225c5793b16fa6ef4 /tmp/machine-guest-tools_riscv64.deb
+EOF
 
 ARG MACHINE_GUEST_TOOLS_VERSION=0.17.1
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
-set -e
+set -eu
+
 apt-get install -y --no-install-recommends \
-    busybox-static
+  busybox-static
 
 cd /tmp
 busybox wget https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb
-echo "96625d97354c1cc905a8630f3d715f64b14bc5b89f3e30913d2eb02da3a01f20a7784d32c2ed340ca401dce4d1bc0e6bebfc3fbb3808725225c5793b16fa6ef4 /tmp/machine-guest-tools_riscv64.deb" \
-    | sha512sum -c
-apt-get install -y --no-install-recommends \
-    /tmp/machine-guest-tools_riscv64.deb
+sha512sum -c /tmp/machine-guest-tools_riscv64.deb.sha512sum
+
+apt-get install -y --no-install-recommends /tmp/machine-guest-tools_riscv64.deb
 rm /tmp/machine-guest-tools_riscv64.deb
 
+# Fix non-determinism issue when installing machine-guest-tools
+cp -a /etc/shadow /etc/shadow-
+
+# Strip non-determinism
 rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
+apt-get dist-clean
 EOF
 
 ENV PATH="/opt/cartesi/bin:/opt/cartesi/dapp:${PATH}"
 
 WORKDIR /opt/cartesi/dapp
-COPY --from=cross-build-stage /opt/cartesi/dapp/target/riscv64gc-unknown-linux-gnu/release/dapp .
+COPY --from=cross-builder /opt/cartesi/dapp/target/riscv64gc-unknown-linux-gnu/release/dapp .
 
 ENV ROLLUP_HTTP_SERVER_URL="http://127.0.0.1:5004"
 


### PR DESCRIPTION
Depends on https://github.com/cartesi/cli/pull/329

This pull request introduces PHP support to the project, including a new Docker build pipeline, initial PHP application code, and dependency management. The main changes are grouped below:

**Build and CI Integration:**
* Added `php` to the list of languages in the GitHub Actions workflow to enable building and testing PHP components.

**Docker and Environment Setup:**
* Added a `php/Dockerfile` that builds a deterministic PHP 8.4.11 container for the riscv64 architecture, installs Composer and dependencies, and prepares the runtime environment for Cartesi rollup applications.
* Updated `.dockerignore` and `.gitignore` in the `php` directory to exclude `.cartesi` and `vendor` directories from Docker builds and version control.

**Dependency Management:**
* Introduced a `composer.json` file in the `php` directory specifying `guzzlehttp/guzzle` as a required dependency for HTTP client functionality.

**Application Boilerplate:**
* Added an initial `index.php` script that implements a basic event loop for handling Cartesi rollup requests, using Guzzle for HTTP communication and placeholder logic for request handling.