### PR TITLE
Remove --platform=linux/riscv64 from Dockerfiles

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,7 +35,7 @@ jobs:
           node-version: current
 
       - name: Install Cartesi CLI
-        run: npm install -g @cartesi/cli@2.0.0-alpha.0
+        run: npm install -g @cartesi/cli@2.0.0-alpha.1
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/cpp-low-level/Dockerfile
+++ b/cpp-low-level/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker.io/docker/dockerfile:1
 ARG MACHINE_EMULATOR_TOOLS_VERSION=0.16.1
-FROM --platform=linux/riscv64 ubuntu:22.04 AS builder
+FROM ubuntu:22.04 AS builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
@@ -24,7 +24,7 @@ WORKDIR /opt/cartesi/dapp
 COPY . .
 RUN make
 
-FROM --platform=linux/riscv64 ubuntu:22.04
+FROM ubuntu:22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF

--- a/cpp/Dockerfile
+++ b/cpp/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker.io/docker/dockerfile:1
-FROM --platform=linux/riscv64 ubuntu:22.04 AS builder
+FROM ubuntu:22.04 AS builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
@@ -20,7 +20,7 @@ WORKDIR /opt/cartesi/dapp
 COPY . .
 RUN make
 
-FROM --platform=linux/riscv64 ubuntu:22.04
+FROM ubuntu:22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker.io/docker/dockerfile:1
-FROM ubuntu:22.04 AS build-stage
+FROM --platform=$BUILDPLATFORM ubuntu:22.04 AS build-stage
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
@@ -30,7 +30,7 @@ COPY src .
 RUN make
 
 # runtime stage: produces final image that will be executed
-FROM --platform=linux/riscv64 ubuntu:22.04
+FROM ubuntu:22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF

--- a/javascript/Dockerfile
+++ b/javascript/Dockerfile
@@ -6,7 +6,7 @@
 # If any needed dependencies rely on native binaries, you must use
 # a riscv64 image such as cartesi/node:20-jammy for the build stage,
 # to ensure that the appropriate binaries will be generated.
-FROM node:20.16.0-bookworm AS build-stage
+FROM --platform=$BUILDPLATFORM node:20.16.0-bookworm AS build-stage
 
 WORKDIR /opt/cartesi/dapp
 COPY . .
@@ -17,7 +17,7 @@ RUN yarn install && yarn build
 # Here the image's platform MUST be linux/riscv64.
 # Give preference to small base images, which lead to better start-up
 # performance when loading the Cartesi Machine.
-FROM --platform=linux/riscv64 cartesi/node:20.16.0-jammy-slim
+FROM cartesi/node:20.16.0-jammy-slim
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF

--- a/lua/Dockerfile
+++ b/lua/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker.io/docker/dockerfile:1
-FROM --platform=linux/riscv64 ubuntu:22.04 AS builder
+FROM ubuntu:22.04 AS builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
@@ -16,7 +16,7 @@ luarocks install --lua-version=5.4 luasocket 3.1.0-1
 luarocks install --lua-version=5.4 dkjson 2.6-1
 EOF
 
-FROM --platform=linux/riscv64 ubuntu:22.04
+FROM ubuntu:22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker.io/docker/dockerfile:1
-FROM --platform=linux/riscv64 cartesi/python:3.10-slim-jammy
+FROM cartesi/python:3.10-slim-jammy
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker.io/docker/dockerfile:1
-FROM --platform=linux/riscv64 ubuntu:22.04 AS base
+FROM ubuntu:22.04 AS base
 
 RUN apt-get update
 

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker.io/docker/dockerfile:1
-FROM ubuntu:22.04 AS builder
+FROM --platform=$BUILDPLATFORM ubuntu:22.04 AS builder
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
@@ -43,7 +43,7 @@ WORKDIR /opt/cartesi/dapp
 COPY . .
 RUN cargo build --release
 
-FROM --platform=linux/riscv64 ubuntu:22.04
+FROM ubuntu:22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF

--- a/typescript/Dockerfile
+++ b/typescript/Dockerfile
@@ -6,7 +6,7 @@
 # If any needed dependencies rely on native binaries, you must use
 # a riscv64 image such as cartesi/node:20-jammy for the build stage,
 # to ensure that the appropriate binaries will be generated.
-FROM node:20.16.0-bookworm AS build-stage
+FROM --platform=$BUILDPLATFORM node:20.16.0-bookworm AS build-stage
 
 WORKDIR /opt/cartesi/dapp
 COPY . .
@@ -17,7 +17,7 @@ RUN yarn install && yarn build
 # Here the image's platform MUST be linux/riscv64.
 # Give preference to small base images, which lead to better start-up
 # performance when loading the Cartesi Machine.
-FROM --platform=linux/riscv64 cartesi/node:20.16.0-jammy-slim
+FROM cartesi/node:20.16.0-jammy-slim
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF


### PR DESCRIPTION
Since this is enforced by the cli, we don't need to define it.