### PR TITLE
Rust template update

### DIFF
--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:22.04 AS builder
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.72.0
+    RUST_VERSION=1.82.0
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -35,7 +35,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut status = "accept";
     loop {
         println!("Sending finish");
-        let response = object! {"status" => status.clone()};
+        let response = object! {"status" => status};
         let request = hyper::Request::builder()
             .method(hyper::Method::POST)
             .header(hyper::header::CONTENT_TYPE, "application/json")


### PR DESCRIPTION
Bump rust to 1.82.0

Remove unnecessary clone, removing compilation warning.
