### PR TITLE
ci: bump @cartesi/cli to v2.0.0-alpha.8

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,7 +35,7 @@ jobs:
           node-version: current
 
       - name: Install Cartesi CLI
-        run: npm install -g @cartesi/cli@2.0.0-alpha.1
+        run: npm install -g @cartesi/cli@2.0.0-alpha.8
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
Depends on the release of `@cartesi-cli:2.0.0-alpha.8`
