### PR TITLE
Bump guest tools to 0.17.0 test6 deb package

### DIFF
--- a/cpp-low-level/Dockerfile
+++ b/cpp-low-level/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker.io/docker/dockerfile:1
-ARG MACHINE_GUEST_TOOLS_VERSION=0.17.0-test3
+ARG MACHINE_GUEST_TOOLS_VERSION=0.17.0-test6
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
@@ -30,20 +30,22 @@ apt-get install -y --no-install-recommends \
   autoconf \
   automake \
   build-essential \
+  busybox-static \
   libtool \
   pkg-config
 rm -rf /var/lib/apt/lists/*
 EOF
 
 ARG MACHINE_GUEST_TOOLS_VERSION
-ADD https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.tar.gz  /tmp/machine-guest-tools_riscv64.tar.gz
+ADD https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb  /tmp/machine-guest-tools_riscv64.deb
 
 RUN <<EOF
 set -e
-echo "944cb99a021fe94291bbd2682c22cae7be51bc5dc9120f720890ec420dd488f1f92a7fba26d3cc48037f212126de8042e41d3d6bda2c6df0b5d3cc43fe1eb27a /tmp/machine-guest-tools_riscv64.tar.gz" \
+echo "850ddd259832497d122f05da54f91217852d57dd47c24a02efa66a44843b0f9c8c29cd81d3fa6d0f804d4a0b89466af00e619348dde94f23150cfd0f8bc930c8 /tmp/machine-guest-tools_riscv64.deb" \
   | sha512sum -c
-tar -C / -xzf /tmp/machine-guest-tools_riscv64.tar.gz
-rm /tmp/machine-guest-tools_riscv64.tar.gz
+apt-get install -y --no-install-recommends \
+  /tmp/machine-guest-tools_riscv64.deb
+rm /tmp/machine-guest-tools_riscv64.deb
 EOF
 
 WORKDIR /opt/cartesi/dapp
@@ -54,24 +56,22 @@ RUN make
 # runtime stage: produces final image that will be executed
 FROM base
 
+ARG MACHINE_GUEST_TOOLS_VERSION
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
 apt-get install -y --no-install-recommends \
   busybox-static
-rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
-useradd --create-home --user-group dapp
-EOF
 
-ARG MACHINE_GUEST_TOOLS_VERSION
-ADD https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.tar.gz  /tmp/machine-guest-tools_riscv64.tar.gz
-
-RUN <<EOF
-set -e
-echo "944cb99a021fe94291bbd2682c22cae7be51bc5dc9120f720890ec420dd488f1f92a7fba26d3cc48037f212126de8042e41d3d6bda2c6df0b5d3cc43fe1eb27a /tmp/machine-guest-tools_riscv64.tar.gz" \
+cd /tmp
+busybox wget https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb
+echo "850ddd259832497d122f05da54f91217852d57dd47c24a02efa66a44843b0f9c8c29cd81d3fa6d0f804d4a0b89466af00e619348dde94f23150cfd0f8bc930c8 /tmp/machine-guest-tools_riscv64.deb" \
   | sha512sum -c
-tar -C / -xzf /tmp/machine-guest-tools_riscv64.tar.gz
-rm /tmp/machine-guest-tools_riscv64.tar.gz
+apt-get install -y --no-install-recommends \
+  /tmp/machine-guest-tools_riscv64.deb
+rm /tmp/machine-guest-tools_riscv64.deb
+
+rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
 EOF
 
 ENV PATH="/opt/cartesi/bin:${PATH}"

--- a/cpp-low-level/Dockerfile
+++ b/cpp-low-level/Dockerfile
@@ -4,7 +4,7 @@ ARG MACHINE_GUEST_TOOLS_VERSION=0.17.0-test3
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
 ARG UBUNTU_TAG=noble-20250127
-ARG APT_UPDATE_SNAPSHOT=20250127T030400Z
+ARG APT_UPDATE_SNAPSHOT=20250408T030400Z
 
 ################################################################################
 # riscv64 base stage

--- a/cpp/Dockerfile
+++ b/cpp/Dockerfile
@@ -41,24 +41,22 @@ RUN make
 # runtime stage: produces final image that will be executed
 FROM base
 
+ARG MACHINE_GUEST_TOOLS_VERSION=0.17.0-test6
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
 apt-get install -y --no-install-recommends \
   busybox-static
-rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
-useradd --create-home --user-group dapp
-EOF
 
-ARG MACHINE_GUEST_TOOLS_VERSION=0.17.0-test3
-ADD https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.tar.gz  /tmp/machine-guest-tools_riscv64.tar.gz
-
-RUN <<EOF
-set -e
-echo "944cb99a021fe94291bbd2682c22cae7be51bc5dc9120f720890ec420dd488f1f92a7fba26d3cc48037f212126de8042e41d3d6bda2c6df0b5d3cc43fe1eb27a /tmp/machine-guest-tools_riscv64.tar.gz" \
+cd /tmp
+busybox wget https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb
+echo "850ddd259832497d122f05da54f91217852d57dd47c24a02efa66a44843b0f9c8c29cd81d3fa6d0f804d4a0b89466af00e619348dde94f23150cfd0f8bc930c8 /tmp/machine-guest-tools_riscv64.deb" \
   | sha512sum -c
-tar -C / -xzf /tmp/machine-guest-tools_riscv64.tar.gz
-rm /tmp/machine-guest-tools_riscv64.tar.gz
+apt-get install -y --no-install-recommends \
+  /tmp/machine-guest-tools_riscv64.deb
+rm /tmp/machine-guest-tools_riscv64.deb
+
+rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
 EOF
 
 ENV PATH="/opt/cartesi/bin:${PATH}"

--- a/cpp/Dockerfile
+++ b/cpp/Dockerfile
@@ -3,7 +3,7 @@
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
 ARG UBUNTU_TAG=noble-20250127
-ARG APT_UPDATE_SNAPSHOT=20250127T030400Z
+ARG APT_UPDATE_SNAPSHOT=20250408T030400Z
 
 ################################################################################
 # riscv64 base stage

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -3,7 +3,7 @@
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
 ARG UBUNTU_TAG=noble-20250127
-ARG APT_UPDATE_SNAPSHOT=20250127T030400Z
+ARG APT_UPDATE_SNAPSHOT=20250408T030400Z
 
 ################################################################################
 # riscv64 base stage

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -65,24 +65,22 @@ RUN make
 # runtime stage: produces final image that will be executed
 FROM base-riscv64
 
+ARG MACHINE_GUEST_TOOLS_VERSION=0.17.0-test6
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
 apt-get install -y --no-install-recommends \
   busybox-static
-rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
-useradd --create-home --user-group dapp
-EOF
 
-ARG MACHINE_GUEST_TOOLS_VERSION=0.17.0-test3
-ADD https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.tar.gz  /tmp/machine-guest-tools_riscv64.tar.gz
-
-RUN <<EOF
-set -e
-echo "944cb99a021fe94291bbd2682c22cae7be51bc5dc9120f720890ec420dd488f1f92a7fba26d3cc48037f212126de8042e41d3d6bda2c6df0b5d3cc43fe1eb27a /tmp/machine-guest-tools_riscv64.tar.gz" \
+cd /tmp
+busybox wget https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb
+echo "850ddd259832497d122f05da54f91217852d57dd47c24a02efa66a44843b0f9c8c29cd81d3fa6d0f804d4a0b89466af00e619348dde94f23150cfd0f8bc930c8 /tmp/machine-guest-tools_riscv64.deb" \
   | sha512sum -c
-tar -C / -xzf /tmp/machine-guest-tools_riscv64.tar.gz
-rm /tmp/machine-guest-tools_riscv64.tar.gz
+apt-get install -y --no-install-recommends \
+  /tmp/machine-guest-tools_riscv64.deb
+rm /tmp/machine-guest-tools_riscv64.deb
+
+rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
 EOF
 
 ENV PATH="/opt/cartesi/bin:${PATH}"

--- a/javascript/Dockerfile
+++ b/javascript/Dockerfile
@@ -2,7 +2,7 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG APT_UPDATE_SNAPSHOT=20250127T030400Z
+ARG APT_UPDATE_SNAPSHOT=20250408T030400Z
 
 ################################################################################
 # riscv64 base stage

--- a/javascript/Dockerfile
+++ b/javascript/Dockerfile
@@ -40,25 +40,23 @@ RUN yarn build
 # performance when loading the Cartesi Machine.
 FROM base
 
+ARG MACHINE_GUEST_TOOLS_VERSION=0.17.0-test6
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
 apt-get update
 apt-get install -y --no-install-recommends \
   busybox-static
-rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
-useradd --create-home --user-group dapp
-EOF
 
-ARG MACHINE_GUEST_TOOLS_VERSION=0.17.0-test3
-ADD https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.tar.gz  /tmp/machine-guest-tools_riscv64.tar.gz
-
-RUN <<EOF
-set -e
-echo "944cb99a021fe94291bbd2682c22cae7be51bc5dc9120f720890ec420dd488f1f92a7fba26d3cc48037f212126de8042e41d3d6bda2c6df0b5d3cc43fe1eb27a /tmp/machine-guest-tools_riscv64.tar.gz" \
+cd /tmp
+busybox wget https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb
+echo "850ddd259832497d122f05da54f91217852d57dd47c24a02efa66a44843b0f9c8c29cd81d3fa6d0f804d4a0b89466af00e619348dde94f23150cfd0f8bc930c8 /tmp/machine-guest-tools_riscv64.deb" \
   | sha512sum -c
-tar -C / -xzf /tmp/machine-guest-tools_riscv64.tar.gz
-rm /tmp/machine-guest-tools_riscv64.tar.gz
+apt-get install -y --no-install-recommends \
+  /tmp/machine-guest-tools_riscv64.deb
+rm /tmp/machine-guest-tools_riscv64.deb
+
+rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
 EOF
 
 ENV PATH="/opt/cartesi/bin:${PATH}"

--- a/lua/Dockerfile
+++ b/lua/Dockerfile
@@ -3,7 +3,7 @@
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
 ARG UBUNTU_TAG=noble-20250127
-ARG APT_UPDATE_SNAPSHOT=20250127T030400Z
+ARG APT_UPDATE_SNAPSHOT=20250408T030400Z
 
 ################################################################################
 # riscv64 base stage

--- a/lua/Dockerfile
+++ b/lua/Dockerfile
@@ -40,6 +40,7 @@ EOF
 # riscv64 final stage
 FROM base
 
+ARG MACHINE_GUEST_TOOLS_VERSION=0.17.0-test6
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
@@ -47,19 +48,16 @@ apt-get install -y --no-install-recommends \
   busybox-static \
   liblua5.4-dev \
   lua5.4
-rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
-useradd --create-home --user-group dapp
-EOF
 
-ARG MACHINE_GUEST_TOOLS_VERSION=0.17.0-test3
-ADD https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.tar.gz  /tmp/machine-guest-tools_riscv64.tar.gz
-
-RUN <<EOF
-set -e
-echo "944cb99a021fe94291bbd2682c22cae7be51bc5dc9120f720890ec420dd488f1f92a7fba26d3cc48037f212126de8042e41d3d6bda2c6df0b5d3cc43fe1eb27a /tmp/machine-guest-tools_riscv64.tar.gz" \
+cd /tmp
+busybox wget https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb
+echo "850ddd259832497d122f05da54f91217852d57dd47c24a02efa66a44843b0f9c8c29cd81d3fa6d0f804d4a0b89466af00e619348dde94f23150cfd0f8bc930c8 /tmp/machine-guest-tools_riscv64.deb" \
   | sha512sum -c
-tar -C / -xzf /tmp/machine-guest-tools_riscv64.tar.gz
-rm /tmp/machine-guest-tools_riscv64.tar.gz
+apt-get install -y --no-install-recommends \
+  /tmp/machine-guest-tools_riscv64.deb
+rm /tmp/machine-guest-tools_riscv64.deb
+
+rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
 EOF
 
 COPY --from=builder /usr/local/lib/lua /usr/local/lib/lua

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -25,24 +25,22 @@ EOF
 # performance when loading the Cartesi Machine.
 FROM base
 
+ARG MACHINE_GUEST_TOOLS_VERSION=0.17.0-test6
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
 apt-get install -y --no-install-recommends \
   busybox-static
-rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
-useradd --create-home --user-group dapp
-EOF
 
-ARG MACHINE_GUEST_TOOLS_VERSION=0.17.0-test3
-ADD https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.tar.gz  /tmp/machine-guest-tools_riscv64.tar.gz
-
-RUN <<EOF
-set -e
-echo "944cb99a021fe94291bbd2682c22cae7be51bc5dc9120f720890ec420dd488f1f92a7fba26d3cc48037f212126de8042e41d3d6bda2c6df0b5d3cc43fe1eb27a /tmp/machine-guest-tools_riscv64.tar.gz" \
+cd /tmp
+busybox wget https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb
+echo "850ddd259832497d122f05da54f91217852d57dd47c24a02efa66a44843b0f9c8c29cd81d3fa6d0f804d4a0b89466af00e619348dde94f23150cfd0f8bc930c8 /tmp/machine-guest-tools_riscv64.deb" \
   | sha512sum -c
-tar -C / -xzf /tmp/machine-guest-tools_riscv64.tar.gz
-rm /tmp/machine-guest-tools_riscv64.tar.gz
+apt-get install -y --no-install-recommends \
+  /tmp/machine-guest-tools_riscv64.deb
+rm /tmp/machine-guest-tools_riscv64.deb
+
+rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
 EOF
 
 ENV PATH="/opt/cartesi/bin:${PATH}"

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -2,7 +2,7 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG APT_UPDATE_SNAPSHOT=20250127T030400Z
+ARG APT_UPDATE_SNAPSHOT=20250408T030400Z
 
 ################################################################################
 # riscv64 base stage

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -3,7 +3,7 @@
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
 ARG UBUNTU_TAG=noble-20250127
-ARG APT_UPDATE_SNAPSHOT=20250127T030400Z
+ARG APT_UPDATE_SNAPSHOT=20250408T030400Z
 
 ################################################################################
 # riscv64 base stage

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -44,26 +44,23 @@ EOF
 ################################################################################
 # runtime stage: produces final image that will be executed
 FROM base
-
+ARG MACHINE_GUEST_TOOLS_VERSION=0.17.0-test6
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
 apt-get install -y --no-install-recommends \
   busybox-static \
   ruby
-rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
-useradd --create-home --user-group dapp
-EOF
 
-ARG MACHINE_GUEST_TOOLS_VERSION=0.17.0-test3
-ADD https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.tar.gz  /tmp/machine-guest-tools_riscv64.tar.gz
-
-RUN <<EOF
-set -e
-echo "944cb99a021fe94291bbd2682c22cae7be51bc5dc9120f720890ec420dd488f1f92a7fba26d3cc48037f212126de8042e41d3d6bda2c6df0b5d3cc43fe1eb27a /tmp/machine-guest-tools_riscv64.tar.gz" \
+cd /tmp
+busybox wget https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb
+echo "850ddd259832497d122f05da54f91217852d57dd47c24a02efa66a44843b0f9c8c29cd81d3fa6d0f804d4a0b89466af00e619348dde94f23150cfd0f8bc930c8 /tmp/machine-guest-tools_riscv64.deb" \
   | sha512sum -c
-tar -C / -xzf /tmp/machine-guest-tools_riscv64.tar.gz
-rm /tmp/machine-guest-tools_riscv64.tar.gz
+apt-get install -y --no-install-recommends \
+  /tmp/machine-guest-tools_riscv64.deb
+rm /tmp/machine-guest-tools_riscv64.deb
+
+rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
 EOF
 
 ENV PATH="/opt/cartesi/bin:${PATH}"

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -3,7 +3,7 @@
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
 ARG UBUNTU_TAG=noble-20250127
-ARG APT_UPDATE_SNAPSHOT=20250127T030400Z
+ARG APT_UPDATE_SNAPSHOT=20250408T030400Z
 
 ################################################################################
 # riscv64 base stage

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -80,24 +80,22 @@ RUN cargo build --release
 # runtime stage: produces final image that will be executed
 FROM base-riscv64
 
+ARG MACHINE_GUEST_TOOLS_VERSION=0.17.0-test6
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
 apt-get install -y --no-install-recommends \
     busybox-static
+
+cd /tmp
+busybox wget https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb
+echo "850ddd259832497d122f05da54f91217852d57dd47c24a02efa66a44843b0f9c8c29cd81d3fa6d0f804d4a0b89466af00e619348dde94f23150cfd0f8bc930c8 /tmp/machine-guest-tools_riscv64.deb" \
+    | sha512sum -c
+apt-get install -y --no-install-recommends \
+    /tmp/machine-guest-tools_riscv64.deb
+rm /tmp/machine-guest-tools_riscv64.deb
+
 rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
-useradd --create-home --user-group dapp
-EOF
-
-ARG MACHINE_GUEST_TOOLS_VERSION=0.17.0-test3
-ADD https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.tar.gz  /tmp/machine-guest-tools_riscv64.tar.gz
-
-RUN <<EOF
-set -e
-echo "944cb99a021fe94291bbd2682c22cae7be51bc5dc9120f720890ec420dd488f1f92a7fba26d3cc48037f212126de8042e41d3d6bda2c6df0b5d3cc43fe1eb27a /tmp/machine-guest-tools_riscv64.tar.gz" \
-  | sha512sum -c
-tar -C / -xzf /tmp/machine-guest-tools_riscv64.tar.gz
-rm /tmp/machine-guest-tools_riscv64.tar.gz
 EOF
 
 ENV PATH="/opt/cartesi/bin:/opt/cartesi/dapp:${PATH}"

--- a/typescript/Dockerfile
+++ b/typescript/Dockerfile
@@ -41,24 +41,22 @@ RUN yarn build
 # performance when loading the Cartesi Machine.
 FROM base
 
+ARG MACHINE_GUEST_TOOLS_VERSION=0.17.0-test6
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
 apt-get install -y --no-install-recommends \
   busybox-static
-rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
-useradd --create-home --user-group dapp
-EOF
 
-ARG MACHINE_GUEST_TOOLS_VERSION=0.17.0-test3
-ADD https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.tar.gz  /tmp/machine-guest-tools_riscv64.tar.gz
-
-RUN <<EOF
-set -e
-echo "944cb99a021fe94291bbd2682c22cae7be51bc5dc9120f720890ec420dd488f1f92a7fba26d3cc48037f212126de8042e41d3d6bda2c6df0b5d3cc43fe1eb27a /tmp/machine-guest-tools_riscv64.tar.gz" \
+cd /tmp
+busybox wget https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb
+echo "850ddd259832497d122f05da54f91217852d57dd47c24a02efa66a44843b0f9c8c29cd81d3fa6d0f804d4a0b89466af00e619348dde94f23150cfd0f8bc930c8 /tmp/machine-guest-tools_riscv64.deb" \
   | sha512sum -c
-tar -C / -xzf /tmp/machine-guest-tools_riscv64.tar.gz
-rm /tmp/machine-guest-tools_riscv64.tar.gz
+apt-get install -y --no-install-recommends \
+  /tmp/machine-guest-tools_riscv64.deb
+rm /tmp/machine-guest-tools_riscv64.deb
+
+rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
 EOF
 
 ENV PATH="/opt/cartesi/bin:${PATH}"

--- a/typescript/Dockerfile
+++ b/typescript/Dockerfile
@@ -2,7 +2,7 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG APT_UPDATE_SNAPSHOT=20250127T030400Z
+ARG APT_UPDATE_SNAPSHOT=20250408T030400Z
 
 ################################################################################
 # riscv64 base stage


### PR DESCRIPTION
This pull request includes updates to the Dockerfiles across multiple programming language directories to improve the build process and update dependencies. The most important changes include updating the `MACHINE_GUEST_TOOLS_VERSION` to `0.17.0-test6`, changing the method of downloading and verifying the `machine-guest-tools` package, and updating the `APT_UPDATE_SNAPSHOT` date.

Dependency updates:

* Updated `MACHINE_GUEST_TOOLS_VERSION` to `0.17.0-test6` in all Dockerfiles. [[1]](diffhunk://#diff-4ce5ed242867709da66b465542643f5c4d0f37ca663a2543263c150a50dde2c0L2-R7) [[2]](diffhunk://#diff-3a4cf0094e745eb8d6156c50a7cc2f5c2bfeac389a9d1477f08320a0253891ceR44-R60) [[3]](diffhunk://#diff-e7c951435e49f58cbf8ae82360edd2a5fa60f2d369a01a37abac831d84cdc88dR68-R84) [[4]](diffhunk://#diff-f408b8e465d2b31e38dd296f380471a4e92cb16483dbd7a47fba9a6c18fbcb80L49-R59) [[5]](diffhunk://#diff-568a58385ab1ea65860e040bbfe1241f0cd1f28cdbb6884862844dfc89ede316R43-R61) [[6]](diffhunk://#diff-f70412486b2e4b00416a0b6ec8862d81e3d8d15b0a89f10501881f8bb6ebc8d6R83-R99) [[7]](diffhunk://#diff-7d153ffddf01fb102b3224097d467d3ffaa668fc9b251be2a4050061aea40305R44-R60) [[8]](diffhunk://#diff-4b62900532c579e3c7c952ed7e68a5614cfb8f35adf4640c4523c54fd3e29271L47-R65) [[9]](diffhunk://#diff-c4c9f41a561e18e28581e72d6e45de6aa258c28df8bcb6dad2241ac174d11185R28-R44)

Build process improvements:

* Changed the method of downloading and verifying the `machine-guest-tools` package from using `tar.gz` to `deb` format and using `busybox wget` for downloading in all Dockerfiles. [[1]](diffhunk://#diff-4ce5ed242867709da66b465542643f5c4d0f37ca663a2543263c150a50dde2c0L62-R72) [[2]](diffhunk://#diff-3a4cf0094e745eb8d6156c50a7cc2f5c2bfeac389a9d1477f08320a0253891ceR44-R60) [[3]](diffhunk://#diff-e7c951435e49f58cbf8ae82360edd2a5fa60f2d369a01a37abac831d84cdc88dR68-R84) [[4]](diffhunk://#diff-f408b8e465d2b31e38dd296f380471a4e92cb16483dbd7a47fba9a6c18fbcb80L49-R59) [[5]](diffhunk://#diff-568a58385ab1ea65860e040bbfe1241f0cd1f28cdbb6884862844dfc89ede316R43-R61) [[6]](diffhunk://#diff-f70412486b2e4b00416a0b6ec8862d81e3d8d15b0a89f10501881f8bb6ebc8d6R83-R99) [[7]](diffhunk://#diff-7d153ffddf01fb102b3224097d467d3ffaa668fc9b251be2a4050061aea40305R44-R60) [[8]](diffhunk://#diff-4b62900532c579e3c7c952ed7e68a5614cfb8f35adf4640c4523c54fd3e29271L47-R65) [[9]](diffhunk://#diff-c4c9f41a561e18e28581e72d6e45de6aa258c28df8bcb6dad2241ac174d11185R28-R44)

Date updates:

* Updated `APT_UPDATE_SNAPSHOT` to `20250408T030400Z` in all Dockerfiles to ensure consistent package versions. [[1]](diffhunk://#diff-4ce5ed242867709da66b465542643f5c4d0f37ca663a2543263c150a50dde2c0L2-R7) [[2]](diffhunk://#diff-3a4cf0094e745eb8d6156c50a7cc2f5c2bfeac389a9d1477f08320a0253891ceL6-R6) [[3]](diffhunk://#diff-e7c951435e49f58cbf8ae82360edd2a5fa60f2d369a01a37abac831d84cdc88dL6-R6) [[4]](diffhunk://#diff-f408b8e465d2b31e38dd296f380471a4e92cb16483dbd7a47fba9a6c18fbcb80L5-R5) [[5]](diffhunk://#diff-568a58385ab1ea65860e040bbfe1241f0cd1f28cdbb6884862844dfc89ede316L6-R6) [[6]](diffhunk://#diff-f70412486b2e4b00416a0b6ec8862d81e3d8d15b0a89f10501881f8bb6ebc8d6L6-R6) [[7]](diffhunk://#diff-7d153ffddf01fb102b3224097d467d3ffaa668fc9b251be2a4050061aea40305L5-R5) [[8]](diffhunk://#diff-4b62900532c579e3c7c952ed7e68a5614cfb8f35adf4640c4523c54fd3e29271L6-R6) [[9]](diffhunk://#diff-c4c9f41a561e18e28581e72d6e45de6aa258c28df8bcb6dad2241ac174d11185L5-R5)