### PR TITLE
chore: bump ubuntu baseimage to noble-20250404

### DIFF
--- a/cpp-low-level/Dockerfile
+++ b/cpp-low-level/Dockerfile
@@ -3,7 +3,7 @@ ARG MACHINE_GUEST_TOOLS_VERSION=0.17.0-test6
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG UBUNTU_TAG=noble-20250127
+ARG UBUNTU_TAG=noble-20250404
 ARG APT_UPDATE_SNAPSHOT=20250408T030400Z
 
 ################################################################################

--- a/cpp/Dockerfile
+++ b/cpp/Dockerfile
@@ -2,7 +2,7 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG UBUNTU_TAG=noble-20250127
+ARG UBUNTU_TAG=noble-20250404
 ARG APT_UPDATE_SNAPSHOT=20250408T030400Z
 
 ################################################################################

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -2,7 +2,7 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG UBUNTU_TAG=noble-20250127
+ARG UBUNTU_TAG=noble-20250404
 ARG APT_UPDATE_SNAPSHOT=20250408T030400Z
 
 ################################################################################

--- a/lua/Dockerfile
+++ b/lua/Dockerfile
@@ -2,7 +2,7 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG UBUNTU_TAG=noble-20250127
+ARG UBUNTU_TAG=noble-20250404
 ARG APT_UPDATE_SNAPSHOT=20250408T030400Z
 
 ################################################################################

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -2,7 +2,7 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG UBUNTU_TAG=noble-20250127
+ARG UBUNTU_TAG=noble-20250404
 ARG APT_UPDATE_SNAPSHOT=20250408T030400Z
 
 ################################################################################

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -2,7 +2,7 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG UBUNTU_TAG=noble-20250127
+ARG UBUNTU_TAG=noble-20250404
 ARG APT_UPDATE_SNAPSHOT=20250408T030400Z
 
 ################################################################################


### PR DESCRIPTION
Reference: https://github.com/docker-library/official-images/pull/18798