### PR TITLE
feat: bump APT_UPDATE_SNAPSHOT to 20250424T030400Z

### DIFF
--- a/coprocessor/cpp-low-level/Dockerfile
+++ b/coprocessor/cpp-low-level/Dockerfile
@@ -4,7 +4,7 @@ ARG MACHINE_GUEST_TOOLS_VERSION=0.17.0
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
 ARG UBUNTU_TAG=noble-20250404
-ARG APT_UPDATE_SNAPSHOT=20250408T030400Z
+ARG APT_UPDATE_SNAPSHOT=20250424T030400Z
 
 ################################################################################
 # riscv64 base stage

--- a/coprocessor/cpp/Dockerfile
+++ b/coprocessor/cpp/Dockerfile
@@ -3,7 +3,7 @@
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
 ARG UBUNTU_TAG=noble-20250404
-ARG APT_UPDATE_SNAPSHOT=20250408T030400Z
+ARG APT_UPDATE_SNAPSHOT=20250424T030400Z
 
 ################################################################################
 # riscv64 base stage

--- a/coprocessor/go/Dockerfile
+++ b/coprocessor/go/Dockerfile
@@ -3,7 +3,7 @@
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
 ARG UBUNTU_TAG=noble-20250404
-ARG APT_UPDATE_SNAPSHOT=20250408T030400Z
+ARG APT_UPDATE_SNAPSHOT=20250424T030400Z
 
 ################################################################################
 # riscv64 base stage

--- a/coprocessor/javascript/Dockerfile
+++ b/coprocessor/javascript/Dockerfile
@@ -2,7 +2,7 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG APT_UPDATE_SNAPSHOT=20250408T030400Z
+ARG APT_UPDATE_SNAPSHOT=20250424T030400Z
 
 ################################################################################
 # riscv64 base stage

--- a/coprocessor/lua/Dockerfile
+++ b/coprocessor/lua/Dockerfile
@@ -3,7 +3,7 @@
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
 ARG UBUNTU_TAG=noble-20250404
-ARG APT_UPDATE_SNAPSHOT=20250408T030400Z
+ARG APT_UPDATE_SNAPSHOT=20250424T030400Z
 
 ################################################################################
 # riscv64 base stage

--- a/coprocessor/python/Dockerfile
+++ b/coprocessor/python/Dockerfile
@@ -2,7 +2,7 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG APT_UPDATE_SNAPSHOT=20250408T030400Z
+ARG APT_UPDATE_SNAPSHOT=20250424T030400Z
 
 ################################################################################
 # riscv64 base stage

--- a/coprocessor/ruby/Dockerfile
+++ b/coprocessor/ruby/Dockerfile
@@ -3,7 +3,7 @@
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
 ARG UBUNTU_TAG=noble-20250404
-ARG APT_UPDATE_SNAPSHOT=20250408T030400Z
+ARG APT_UPDATE_SNAPSHOT=20250424T030400Z
 
 ################################################################################
 # riscv64 base stage

--- a/coprocessor/rust/Dockerfile
+++ b/coprocessor/rust/Dockerfile
@@ -3,7 +3,7 @@
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
 ARG UBUNTU_TAG=noble-20250404
-ARG APT_UPDATE_SNAPSHOT=20250408T030400Z
+ARG APT_UPDATE_SNAPSHOT=20250424T030400Z
 
 ################################################################################
 # riscv64 base stage

--- a/coprocessor/typescript/Dockerfile
+++ b/coprocessor/typescript/Dockerfile
@@ -2,7 +2,7 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG APT_UPDATE_SNAPSHOT=20250408T030400Z
+ARG APT_UPDATE_SNAPSHOT=20250424T030400Z
 
 ################################################################################
 # riscv64 base stage

--- a/rollups/cpp-low-level/Dockerfile
+++ b/rollups/cpp-low-level/Dockerfile
@@ -4,7 +4,7 @@ ARG MACHINE_GUEST_TOOLS_VERSION=0.17.0
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
 ARG UBUNTU_TAG=noble-20250404
-ARG APT_UPDATE_SNAPSHOT=20250408T030400Z
+ARG APT_UPDATE_SNAPSHOT=20250424T030400Z
 
 ################################################################################
 # riscv64 base stage

--- a/rollups/cpp/Dockerfile
+++ b/rollups/cpp/Dockerfile
@@ -3,7 +3,7 @@
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
 ARG UBUNTU_TAG=noble-20250404
-ARG APT_UPDATE_SNAPSHOT=20250408T030400Z
+ARG APT_UPDATE_SNAPSHOT=20250424T030400Z
 
 ################################################################################
 # riscv64 base stage

--- a/rollups/go/Dockerfile
+++ b/rollups/go/Dockerfile
@@ -3,7 +3,7 @@
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
 ARG UBUNTU_TAG=noble-20250404
-ARG APT_UPDATE_SNAPSHOT=20250408T030400Z
+ARG APT_UPDATE_SNAPSHOT=20250424T030400Z
 
 ################################################################################
 # riscv64 base stage

--- a/rollups/javascript/Dockerfile
+++ b/rollups/javascript/Dockerfile
@@ -2,7 +2,7 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG APT_UPDATE_SNAPSHOT=20250408T030400Z
+ARG APT_UPDATE_SNAPSHOT=20250424T030400Z
 
 ################################################################################
 # riscv64 base stage

--- a/rollups/lua/Dockerfile
+++ b/rollups/lua/Dockerfile
@@ -3,7 +3,7 @@
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
 ARG UBUNTU_TAG=noble-20250404
-ARG APT_UPDATE_SNAPSHOT=20250408T030400Z
+ARG APT_UPDATE_SNAPSHOT=20250424T030400Z
 
 ################################################################################
 # riscv64 base stage

--- a/rollups/python/Dockerfile
+++ b/rollups/python/Dockerfile
@@ -2,7 +2,7 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG APT_UPDATE_SNAPSHOT=20250408T030400Z
+ARG APT_UPDATE_SNAPSHOT=20250424T030400Z
 
 ################################################################################
 # riscv64 base stage

--- a/rollups/ruby/Dockerfile
+++ b/rollups/ruby/Dockerfile
@@ -3,7 +3,7 @@
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
 ARG UBUNTU_TAG=noble-20250404
-ARG APT_UPDATE_SNAPSHOT=20250408T030400Z
+ARG APT_UPDATE_SNAPSHOT=20250424T030400Z
 
 ################################################################################
 # riscv64 base stage

--- a/rollups/rust/Dockerfile
+++ b/rollups/rust/Dockerfile
@@ -3,7 +3,7 @@
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
 ARG UBUNTU_TAG=noble-20250404
-ARG APT_UPDATE_SNAPSHOT=20250408T030400Z
+ARG APT_UPDATE_SNAPSHOT=20250424T030400Z
 
 ################################################################################
 # riscv64 base stage

--- a/rollups/typescript/Dockerfile
+++ b/rollups/typescript/Dockerfile
@@ -2,7 +2,7 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG APT_UPDATE_SNAPSHOT=20250408T030400Z
+ARG APT_UPDATE_SNAPSHOT=20250424T030400Z
 
 ################################################################################
 # riscv64 base stage


### PR DESCRIPTION
perl packages were missing on the previous snapshot due to https://ubuntu.com/security/CVE-2024-56406