### PR TITLE
Use Debian Trixie as baseimage and official language images when available

### DIFF
--- a/cpp-low-level/Dockerfile
+++ b/cpp-low-level/Dockerfile
@@ -1,27 +1,64 @@
 # syntax=docker.io/docker/dockerfile:1
-ARG MACHINE_GUEST_TOOLS_VERSION=0.17.1
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG UBUNTU_TAG=noble-20250910
-ARG APT_UPDATE_SNAPSHOT=20250915T030400Z
+ARG APT_UPDATE_SNAPSHOT=20250908T144407Z
+ARG DEBIAN_TAG=trixie-20250908-slim@sha256:c2880112cc5c61e1200c26f106e4123627b49726375eb5846313da9cca117337
+ARG MACHINE_GUEST_TOOLS_VERSION=0.17.1
+
+FROM scratch AS machine-guest-tools-checksum
+COPY <<EOF /tmp/machine-guest-tools_riscv64.deb.sha512sum
+96625d97354c1cc905a8630f3d715f64b14bc5b89f3e30913d2eb02da3a01f20a7784d32c2ed340ca401dce4d1bc0e6bebfc3fbb3808725225c5793b16fa6ef4 /tmp/machine-guest-tools_riscv64.deb
+EOF
+
+# Configure apt to use snapshot.debian.org
+FROM scratch AS apt-config
+ARG APT_UPDATE_SNAPSHOT
+COPY <<EOF /etc/apt/sources.list.d/debian.sources
+Types: deb
+URIs: http://snapshot.debian.org/archive/debian/${APT_UPDATE_SNAPSHOT}
+Suites: trixie trixie-updates
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+
+Types: deb
+URIs: http://snapshot.debian.org/archive/debian-security/${APT_UPDATE_SNAPSHOT}
+Suites: trixie-security
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+EOF
+
+# Configure apt to accept snapshots for expired suites (security, updates)
+COPY <<EOF /etc/apt/apt.conf.d/10-nocheckvalid
+Acquire::Check-Valid-Until false;
+EOF
+
+# Configure apt to Ignore TLS verify on first apt-get update --snapshot=
+COPY <<EOF /etc/apt/apt.conf.d/99-insecure
+Acquire::https::Verify-Peer false;
+Acquire::https::Verify-Host false;
+EOF
+
 
 ################################################################################
 # riscv64 base stage
-FROM --platform=linux/riscv64 ubuntu:${UBUNTU_TAG} AS base
+FROM --platform=linux/riscv64 debian:${DEBIAN_TAG} AS base
 
-ARG APT_UPDATE_SNAPSHOT
+COPY --link --from=apt-config / /
+
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
-set -eu
+set -e
+
 apt-get update
-apt-get install -y --no-install-recommends ca-certificates curl
-apt-get update --snapshot=${APT_UPDATE_SNAPSHOT}
+apt-get install -y --no-install-recommends \
+    ca-certificates
 EOF
 
 ################################################################################
 # riscv64 builder stage
 FROM base AS builder
+RUN rm /etc/apt/apt.conf.d/99-insecure
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
@@ -33,19 +70,25 @@ apt-get install -y --no-install-recommends \
   busybox-static \
   libtool \
   pkg-config
-rm -rf /var/lib/apt/lists/*
 EOF
 
-ARG MACHINE_GUEST_TOOLS_VERSION
-ADD https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb  /tmp/machine-guest-tools_riscv64.deb
+COPY --link --from=machine-guest-tools-checksum / /
 
+ARG MACHINE_GUEST_TOOLS_VERSION
 RUN <<EOF
-set -e
-echo "96625d97354c1cc905a8630f3d715f64b14bc5b89f3e30913d2eb02da3a01f20a7784d32c2ed340ca401dce4d1bc0e6bebfc3fbb3808725225c5793b16fa6ef4 /tmp/machine-guest-tools_riscv64.deb" \
-  | sha512sum -c
+set -eu
+
 apt-get install -y --no-install-recommends \
-  /tmp/machine-guest-tools_riscv64.deb
+    busybox-static
+
+cd /tmp
+busybox wget https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb
+sha512sum -c /tmp/machine-guest-tools_riscv64.deb.sha512sum
+apt-get install -y --no-install-recommends /tmp/machine-guest-tools_riscv64.deb
+
 rm /tmp/machine-guest-tools_riscv64.deb
+rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
+apt-get dist-clean
 EOF
 
 WORKDIR /opt/cartesi/dapp
@@ -55,26 +98,31 @@ RUN make
 ################################################################################
 # runtime stage: produces final image that will be executed
 FROM base
+RUN rm /etc/apt/apt.conf.d/99-insecure
+
+COPY --link --from=machine-guest-tools-checksum / /
 
 ARG MACHINE_GUEST_TOOLS_VERSION
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
-set -e
+set -eu
+
 apt-get install -y --no-install-recommends \
   busybox-static
 
 cd /tmp
 busybox wget https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb
-echo "96625d97354c1cc905a8630f3d715f64b14bc5b89f3e30913d2eb02da3a01f20a7784d32c2ed340ca401dce4d1bc0e6bebfc3fbb3808725225c5793b16fa6ef4 /tmp/machine-guest-tools_riscv64.deb" \
-  | sha512sum -c
-apt-get install -y --no-install-recommends \
-  /tmp/machine-guest-tools_riscv64.deb
+sha512sum -c /tmp/machine-guest-tools_riscv64.deb.sha512sum
+
+apt-get install -y --no-install-recommends /tmp/machine-guest-tools_riscv64.deb
 rm /tmp/machine-guest-tools_riscv64.deb
 
 # Fix non-determinism issue when installing machine-guest-tools
 cp -a /etc/shadow /etc/shadow-
 
+# Strip non-determinism
 rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
+apt-get dist-clean
 EOF
 
 ENV PATH="/opt/cartesi/bin:${PATH}"

--- a/cpp/Dockerfile
+++ b/cpp/Dockerfile
@@ -2,25 +2,56 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG UBUNTU_TAG=noble-20250910
-ARG APT_UPDATE_SNAPSHOT=20250915T030400Z
+ARG DEBIAN_TAG=trixie-20250908-slim@sha256:c2880112cc5c61e1200c26f106e4123627b49726375eb5846313da9cca117337
+ARG APT_UPDATE_SNAPSHOT=20250908T144407Z
+
+# Configure apt to use snapshot.debian.org
+FROM scratch AS apt-config
+ARG APT_UPDATE_SNAPSHOT
+COPY <<EOF /etc/apt/sources.list.d/debian.sources
+Types: deb
+URIs: http://snapshot.debian.org/archive/debian/${APT_UPDATE_SNAPSHOT}
+Suites: trixie trixie-updates
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+
+Types: deb
+URIs: http://snapshot.debian.org/archive/debian-security/${APT_UPDATE_SNAPSHOT}
+Suites: trixie-security
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+EOF
+
+# Configure apt to accept snapshots for expired suites (security, updates)
+COPY <<EOF /etc/apt/apt.conf.d/10-nocheckvalid
+Acquire::Check-Valid-Until false;
+EOF
+
+# Configure apt to Ignore TLS verify on first apt-get update --snapshot=
+COPY <<EOF /etc/apt/apt.conf.d/99-insecure
+Acquire::https::Verify-Peer false;
+Acquire::https::Verify-Host false;
+EOF
 
 ################################################################################
 # riscv64 base stage
-FROM --platform=linux/riscv64 ubuntu:${UBUNTU_TAG} AS base
+FROM --platform=linux/riscv64 debian:${DEBIAN_TAG} AS base
 
-ARG APT_UPDATE_SNAPSHOT
+COPY --link --from=apt-config / /
+
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
-set -eu
+set -e
+
 apt-get update
-apt-get install -y --no-install-recommends ca-certificates curl
-apt-get update --snapshot=${APT_UPDATE_SNAPSHOT}
+apt-get install -y --no-install-recommends \
+    ca-certificates
 EOF
 
 ################################################################################
 # riscv64 builder stage
 FROM base AS builder
+RUN rm /etc/apt/apt.conf.d/99-insecure
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
@@ -29,8 +60,8 @@ apt-get install -y --no-install-recommends \
   autoconf \
   automake \
   build-essential \
+  curl \
   libtool
-rm -rf /var/lib/apt/lists/*
 EOF
 
 WORKDIR /opt/cartesi/dapp
@@ -40,26 +71,33 @@ RUN make
 ################################################################################
 # runtime stage: produces final image that will be executed
 FROM base
+RUN rm /etc/apt/apt.conf.d/99-insecure
+
+COPY <<EOF /tmp/machine-guest-tools_riscv64.deb.sha512sum
+96625d97354c1cc905a8630f3d715f64b14bc5b89f3e30913d2eb02da3a01f20a7784d32c2ed340ca401dce4d1bc0e6bebfc3fbb3808725225c5793b16fa6ef4 /tmp/machine-guest-tools_riscv64.deb
+EOF
 
 ARG MACHINE_GUEST_TOOLS_VERSION=0.17.1
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
-set -e
+set -eu
+
 apt-get install -y --no-install-recommends \
   busybox-static
 
 cd /tmp
 busybox wget https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb
-echo "96625d97354c1cc905a8630f3d715f64b14bc5b89f3e30913d2eb02da3a01f20a7784d32c2ed340ca401dce4d1bc0e6bebfc3fbb3808725225c5793b16fa6ef4 /tmp/machine-guest-tools_riscv64.deb" \
-  | sha512sum -c
-apt-get install -y --no-install-recommends \
-  /tmp/machine-guest-tools_riscv64.deb
+sha512sum -c /tmp/machine-guest-tools_riscv64.deb.sha512sum
+
+apt-get install -y --no-install-recommends /tmp/machine-guest-tools_riscv64.deb
 rm /tmp/machine-guest-tools_riscv64.deb
 
 # Fix non-determinism issue when installing machine-guest-tools
 cp -a /etc/shadow /etc/shadow-
 
+# Strip non-determinism
 rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
+apt-get dist-clean
 EOF
 
 ENV PATH="/opt/cartesi/bin:${PATH}"

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -2,54 +2,67 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG UBUNTU_TAG=noble-20250910
-ARG APT_UPDATE_SNAPSHOT=20250915T030400Z
+ARG APT_UPDATE_SNAPSHOT=20250908T144407Z
+ARG DEBIAN_TAG=trixie-20250908-slim@sha256:c2880112cc5c61e1200c26f106e4123627b49726375eb5846313da9cca117337
+ARG GO_VERSION=1.24.6
+
+# Configure apt to use snapshot.debian.org
+FROM scratch AS apt-config
+ARG APT_UPDATE_SNAPSHOT
+COPY <<EOF /etc/apt/sources.list.d/debian.sources
+Types: deb
+URIs: http://snapshot.debian.org/archive/debian/${APT_UPDATE_SNAPSHOT}
+Suites: trixie trixie-updates
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+
+Types: deb
+URIs: http://snapshot.debian.org/archive/debian-security/${APT_UPDATE_SNAPSHOT}
+Suites: trixie-security
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+EOF
+
+# Configure apt to accept snapshots for expired suites (security, updates)
+COPY <<EOF /etc/apt/apt.conf.d/10-nocheckvalid
+Acquire::Check-Valid-Until false;
+EOF
+
+# Configure apt to Ignore TLS verify on first apt-get update --snapshot=
+COPY <<EOF /etc/apt/apt.conf.d/99-insecure
+Acquire::https::Verify-Peer false;
+Acquire::https::Verify-Host false;
+EOF
 
 ################################################################################
 # riscv64 base stage
-FROM --platform=linux/riscv64 ubuntu:${UBUNTU_TAG} AS base-riscv64
+FROM --platform=linux/riscv64 debian:${DEBIAN_TAG} AS base
 
-ARG APT_UPDATE_SNAPSHOT
-ARG DEBIAN_FRONTEND=noninteractive
-RUN <<EOF
-set -eu
-apt-get update
-apt-get install -y --no-install-recommends ca-certificates curl
-apt-get update --snapshot=${APT_UPDATE_SNAPSHOT}
-EOF
-
-################################################################################
-# cross base stage
-FROM --platform=$BUILDPLATFORM ubuntu:${UBUNTU_TAG} AS base-cross
-
-ARG APT_UPDATE_SNAPSHOT
-ARG DEBIAN_FRONTEND=noninteractive
-RUN <<EOF
-set -eu
-apt-get update
-apt-get install -y --no-install-recommends ca-certificates curl
-apt-get update --snapshot=${APT_UPDATE_SNAPSHOT}
-EOF
-
-################################################################################
-# cross build stage
-FROM base-cross AS cross-build-stage
+COPY --link --from=apt-config / /
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
+
+apt-get update
 apt-get install -y --no-install-recommends \
-    build-essential \
-    ca-certificates \
-    g++-riscv64-linux-gnu
+    ca-certificates
 EOF
 
-ARG GOVERSION=1.23.2
+################################################################################
+# golang cross build stage
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-trixie AS cross-builder
 
-WORKDIR /opt/build
+COPY --link --from=apt-config / /
 
-RUN curl -fsSL https://go.dev/dl/go${GOVERSION}.linux-$(dpkg --print-architecture).tar.gz | \
-  tar -C /usr/local -xzf -
+ARG DEBIAN_FRONTEND=noninteractive
+RUN <<EOF
+set -eu
+apt-get update
+apt-get install -y --no-install-recommends \
+    build-essential \
+    g++-riscv64-linux-gnu
+EOF
 
 ENV GOOS=linux
 ENV GOARCH=riscv64
@@ -57,39 +70,47 @@ ENV CGO_ENABLED=1
 ENV CC=riscv64-linux-gnu-gcc
 ENV PATH=/usr/local/go/bin:${PATH}
 
+WORKDIR /opt/cartesi/dapp
 COPY src .
-
 RUN make
 
 ################################################################################
 # runtime stage: produces final image that will be executed
-FROM base-riscv64
+FROM base
+RUN rm /etc/apt/apt.conf.d/99-insecure
+
+COPY <<EOF /tmp/machine-guest-tools_riscv64.deb.sha512sum
+96625d97354c1cc905a8630f3d715f64b14bc5b89f3e30913d2eb02da3a01f20a7784d32c2ed340ca401dce4d1bc0e6bebfc3fbb3808725225c5793b16fa6ef4 /tmp/machine-guest-tools_riscv64.deb
+EOF
 
 ARG MACHINE_GUEST_TOOLS_VERSION=0.17.1
 ARG DEBIAN_FRONTEND=noninteractive
+
 RUN <<EOF
-set -e
+set -eu
+
 apt-get install -y --no-install-recommends \
   busybox-static
 
 cd /tmp
 busybox wget https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb
-echo "96625d97354c1cc905a8630f3d715f64b14bc5b89f3e30913d2eb02da3a01f20a7784d32c2ed340ca401dce4d1bc0e6bebfc3fbb3808725225c5793b16fa6ef4 /tmp/machine-guest-tools_riscv64.deb" \
-  | sha512sum -c
-apt-get install -y --no-install-recommends \
-  /tmp/machine-guest-tools_riscv64.deb
+sha512sum -c /tmp/machine-guest-tools_riscv64.deb.sha512sum
+
+apt-get install -y --no-install-recommends /tmp/machine-guest-tools_riscv64.deb
 rm /tmp/machine-guest-tools_riscv64.deb
 
 # Fix non-determinism issue when installing machine-guest-tools
 cp -a /etc/shadow /etc/shadow-
 
+# Strip non-determinism
 rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
+apt-get dist-clean
 EOF
 
 ENV PATH="/opt/cartesi/bin:${PATH}"
 
 WORKDIR /opt/cartesi/dapp
-COPY --from=cross-build-stage /opt/build/dapp .
+COPY --from=cross-builder /opt/cartesi/dapp/dapp .
 
 ENV ROLLUP_HTTP_SERVER_URL="http://127.0.0.1:5004"
 

--- a/lua/Dockerfile
+++ b/lua/Dockerfile
@@ -2,25 +2,56 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG UBUNTU_TAG=noble-20250910
-ARG APT_UPDATE_SNAPSHOT=20250915T030400Z
+ARG DEBIAN_TAG=trixie-20250908-slim@sha256:c2880112cc5c61e1200c26f106e4123627b49726375eb5846313da9cca117337
+ARG APT_UPDATE_SNAPSHOT=20250908T144407Z
+
+# Configure apt to use snapshot.debian.org
+FROM scratch AS apt-config
+ARG APT_UPDATE_SNAPSHOT
+COPY <<EOF /etc/apt/sources.list.d/debian.sources
+Types: deb
+URIs: http://snapshot.debian.org/archive/debian/${APT_UPDATE_SNAPSHOT}
+Suites: trixie trixie-updates
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+
+Types: deb
+URIs: http://snapshot.debian.org/archive/debian-security/${APT_UPDATE_SNAPSHOT}
+Suites: trixie-security
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+EOF
+
+# Configure apt to accept snapshots for expired suites (security, updates)
+COPY <<EOF /etc/apt/apt.conf.d/10-nocheckvalid
+Acquire::Check-Valid-Until false;
+EOF
+
+# Configure apt to Ignore TLS verify on first apt-get update --snapshot=
+COPY <<EOF /etc/apt/apt.conf.d/99-insecure
+Acquire::https::Verify-Peer false;
+Acquire::https::Verify-Host false;
+EOF
 
 ################################################################################
 # riscv64 base stage
-FROM --platform=linux/riscv64 ubuntu:${UBUNTU_TAG} AS base
+FROM --platform=linux/riscv64 debian:${DEBIAN_TAG} AS base
 
-ARG APT_UPDATE_SNAPSHOT
+COPY --link --from=apt-config / /
+
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
-set -eu
+set -e
+
 apt-get update
-apt-get install -y --no-install-recommends ca-certificates
-apt-get update --snapshot=${APT_UPDATE_SNAPSHOT}
+apt-get install -y --no-install-recommends \
+    ca-certificates
 EOF
 
 ################################################################################
 # riscv64 builder stage
 FROM base AS builder
+RUN rm /etc/apt/apt.conf.d/99-insecure
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
@@ -30,7 +61,6 @@ apt-get install -y --no-install-recommends \
   liblua5.4-dev \
   lua5.4 \
   luarocks
-rm -rf /var/lib/apt/lists/*
 
 luarocks install --lua-version=5.4 luasocket 3.1.0-1
 luarocks install --lua-version=5.4 dkjson 2.6-1
@@ -39,34 +69,46 @@ EOF
 ################################################################################
 # riscv64 final stage
 FROM base
+RUN rm /etc/apt/apt.conf.d/99-insecure
+
+COPY <<EOF /tmp/machine-guest-tools_riscv64.deb.sha512sum
+96625d97354c1cc905a8630f3d715f64b14bc5b89f3e30913d2eb02da3a01f20a7784d32c2ed340ca401dce4d1bc0e6bebfc3fbb3808725225c5793b16fa6ef4 /tmp/machine-guest-tools_riscv64.deb
+EOF
 
 ARG MACHINE_GUEST_TOOLS_VERSION=0.17.1
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
-set -e
+set -eu
+
 apt-get install -y --no-install-recommends \
-  busybox-static \
-  liblua5.4-dev \
-  lua5.4
+  busybox-static
 
 cd /tmp
 busybox wget https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb
-echo "96625d97354c1cc905a8630f3d715f64b14bc5b89f3e30913d2eb02da3a01f20a7784d32c2ed340ca401dce4d1bc0e6bebfc3fbb3808725225c5793b16fa6ef4 /tmp/machine-guest-tools_riscv64.deb" \
-  | sha512sum -c
-apt-get install -y --no-install-recommends \
-  /tmp/machine-guest-tools_riscv64.deb
+sha512sum -c /tmp/machine-guest-tools_riscv64.deb.sha512sum
+
+apt-get install -y --no-install-recommends /tmp/machine-guest-tools_riscv64.deb
 rm /tmp/machine-guest-tools_riscv64.deb
 
 # Fix non-determinism issue when installing machine-guest-tools
 cp -a /etc/shadow /etc/shadow-
+EOF
 
+RUN <<EOF
+set -e
+apt-get install -y --no-install-recommends \
+  liblua5.4-dev \
+  lua5.4
+
+# Strip non-determinism
 rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
+apt-get dist-clean
 EOF
 
 COPY --from=builder /usr/local/lib/lua /usr/local/lib/lua
 COPY --from=builder /usr/local/share/lua /usr/local/share/lua
 
-ENV PATH="/opt/cartesi/bin:/opt/cartesi/dapp:${PATH}"
+ENV PATH="/opt/cartesi/bin:${PATH}"
 
 WORKDIR /opt/cartesi/dapp
 COPY . .

--- a/python/.dockerignore
+++ b/python/.dockerignore
@@ -1,0 +1,2 @@
+.cartesi
+.venv

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -2,64 +2,105 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG APT_UPDATE_SNAPSHOT=20250915T030400Z
+ARG APT_UPDATE_SNAPSHOT=20250908T144407Z
+ARG PYTHON_VERSION=3.13.6
 
-################################################################################
-# riscv64 base stage
-FROM --platform=linux/riscv64 cartesi/python:3.13.2-slim-noble AS base
-
+# Configure apt to use snapshot.debian.org
+FROM scratch AS apt-config
 ARG APT_UPDATE_SNAPSHOT
-ARG DEBIAN_FRONTEND=noninteractive
-RUN <<EOF
-set -eu
-apt-get update
-apt-get install -y --no-install-recommends ca-certificates curl
-apt-get update --snapshot=${APT_UPDATE_SNAPSHOT}
+COPY <<EOF /etc/apt/sources.list.d/debian.sources
+Types: deb
+URIs: http://snapshot.debian.org/archive/debian/${APT_UPDATE_SNAPSHOT}
+Suites: trixie trixie-updates
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+
+Types: deb
+URIs: http://snapshot.debian.org/archive/debian-security/${APT_UPDATE_SNAPSHOT}
+Suites: trixie-security
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+EOF
+
+# Configure apt to accept snapshots for expired suites (security, updates)
+COPY <<EOF /etc/apt/apt.conf.d/10-nocheckvalid
+Acquire::Check-Valid-Until false;
+EOF
+
+# Configure apt to Ignore TLS verify on first apt-get update --snapshot=
+COPY <<EOF /etc/apt/apt.conf.d/99-insecure
+Acquire::https::Verify-Peer false;
+Acquire::https::Verify-Host false;
 EOF
 
 ################################################################################
-# runtime stage: produces final image that will be executed
+# riscv64 base stage
+FROM --platform=linux/riscv64 python:${PYTHON_VERSION}-slim-trixie AS base
 
-# Here the image's platform MUST be linux/riscv64.
-# Give preference to small base images, which lead to better start-up
-# performance when loading the Cartesi Machine.
+COPY --link --from=apt-config / /
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN <<EOF
+set -e
+
+apt-get update
+apt-get install -y --no-install-recommends \
+    ca-certificates
+EOF
+
+################################################################################
+# riscv64 builder
+FROM base AS builder
+RUN rm /etc/apt/apt.conf.d/99-insecure
+
+WORKDIR /opt/cartesi/dapp
+RUN python -m venv /opt/cartesi/dapp/venv
+ENV PATH="/opt/cartesi/dapp/venv/bin:$PATH"
+
+COPY requirements.txt .
+RUN pip install -r requirements.txt --no-cache && \
+    find /usr/local/lib -type d -name __pycache__ -exec rm -r {} +
+
+################################################################################
+# runtime stage: produces final image that will be executed
 FROM base
+RUN rm /etc/apt/apt.conf.d/99-insecure
+
+COPY <<EOF /tmp/machine-guest-tools_riscv64.deb.sha512sum
+96625d97354c1cc905a8630f3d715f64b14bc5b89f3e30913d2eb02da3a01f20a7784d32c2ed340ca401dce4d1bc0e6bebfc3fbb3808725225c5793b16fa6ef4 /tmp/machine-guest-tools_riscv64.deb
+EOF
 
 ARG MACHINE_GUEST_TOOLS_VERSION=0.17.1
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
-set -e
+set -eu
+
 apt-get install -y --no-install-recommends \
-  busybox-static
+    busybox-static
 
 cd /tmp
 busybox wget https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb
-echo "96625d97354c1cc905a8630f3d715f64b14bc5b89f3e30913d2eb02da3a01f20a7784d32c2ed340ca401dce4d1bc0e6bebfc3fbb3808725225c5793b16fa6ef4 /tmp/machine-guest-tools_riscv64.deb" \
-  | sha512sum -c
-apt-get install -y --no-install-recommends \
-  /tmp/machine-guest-tools_riscv64.deb
+sha512sum -c /tmp/machine-guest-tools_riscv64.deb.sha512sum
+
+apt-get install -y --no-install-recommends /tmp/machine-guest-tools_riscv64.deb
 rm /tmp/machine-guest-tools_riscv64.deb
 
 # Fix non-determinism issue when installing machine-guest-tools
 cp -a /etc/shadow /etc/shadow-
 
+# Strip non-determinism
 rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
+apt-get dist-clean
 EOF
 
-ENV PATH="/opt/cartesi/bin:${PATH}"
+ENV PATH="/opt/cartesi/dapp/venv/bin:/opt/cartesi/bin:${PATH}"
 
 WORKDIR /opt/cartesi/dapp
-COPY ./requirements.txt .
-
-RUN <<EOF
-set -e
-pip install -r requirements.txt --no-cache
-find /usr/local/lib -type d -name __pycache__ -exec rm -r {} +
-EOF
-
-COPY ./dapp.py .
+COPY --from=builder /opt/cartesi/dapp/venv ./venv
+COPY dapp.py .
 
 ENV ROLLUP_HTTP_SERVER_URL="http://127.0.0.1:5004"
 
+USER dapp
 ENTRYPOINT ["rollup-init"]
 CMD ["python3", "dapp.py"]

--- a/ruby/.dockerignore
+++ b/ruby/.dockerignore
@@ -1,1 +1,2 @@
 .cartesi
+.bundle

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -2,37 +2,69 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG UBUNTU_TAG=noble-20250910
-ARG APT_UPDATE_SNAPSHOT=20250915T030400Z
+ARG APT_UPDATE_SNAPSHOT=20250908T144407Z
+ARG RUBY_VERSION=3.4.5
 
-################################################################################
-# riscv64 base stage
-FROM --platform=linux/riscv64 ubuntu:${UBUNTU_TAG} AS base
-
+# Configure apt to use snapshot.debian.org
+FROM scratch AS apt-config
 ARG APT_UPDATE_SNAPSHOT
-ARG DEBIAN_FRONTEND=noninteractive
-RUN <<EOF
-set -eu
-apt-get update
-apt-get install -y --no-install-recommends ca-certificates curl
-apt-get update --snapshot=${APT_UPDATE_SNAPSHOT}
+COPY <<EOF /etc/apt/sources.list.d/debian.sources
+Types: deb
+URIs: http://snapshot.debian.org/archive/debian/${APT_UPDATE_SNAPSHOT}
+Suites: trixie trixie-updates
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+
+Types: deb
+URIs: http://snapshot.debian.org/archive/debian-security/${APT_UPDATE_SNAPSHOT}
+Suites: trixie-security
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+EOF
+
+# Configure apt to accept snapshots for expired suites (security, updates)
+COPY <<EOF /etc/apt/apt.conf.d/10-nocheckvalid
+Acquire::Check-Valid-Until false;
+EOF
+
+# Configure apt to Ignore TLS verify on first apt-get update --snapshot=
+COPY <<EOF /etc/apt/apt.conf.d/99-insecure
+Acquire::https::Verify-Peer false;
+Acquire::https::Verify-Host false;
 EOF
 
 ################################################################################
-# riscv64 builder stage
+# riscv64 base stage
+FROM --platform=linux/riscv64 ruby:${RUBY_VERSION}-slim-trixie AS base
+
+COPY --link --from=apt-config / /
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN <<EOF
+set -e
+
+apt-get update
+apt-get install -y --no-install-recommends \
+    ca-certificates
+EOF
+
+################################################################################
+# builder stage
 FROM base AS builder
+RUN rm /etc/apt/apt.conf.d/99-insecure
+
+COPY --link --from=apt-config / /
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
 apt-get install -y --no-install-recommends \
-  build-essential \
-  ruby-dev \
-  ruby
-rm -rf /var/apt/lists/*
-gem install bundler --no-document
+  build-essential
 EOF
 
+RUN gem install bundler --no-document
+
+WORKDIR /opt/cartesi/dapp
 COPY Gemfile Gemfile.lock ./
 
 RUN <<EOF
@@ -44,35 +76,45 @@ EOF
 ################################################################################
 # runtime stage: produces final image that will be executed
 FROM base
+RUN rm /etc/apt/apt.conf.d/99-insecure
+
+COPY <<EOF /tmp/machine-guest-tools_riscv64.deb.sha512sum
+96625d97354c1cc905a8630f3d715f64b14bc5b89f3e30913d2eb02da3a01f20a7784d32c2ed340ca401dce4d1bc0e6bebfc3fbb3808725225c5793b16fa6ef4 /tmp/machine-guest-tools_riscv64.deb
+EOF
+
 ARG MACHINE_GUEST_TOOLS_VERSION=0.17.1
 ARG DEBIAN_FRONTEND=noninteractive
+
 RUN <<EOF
-set -e
+set -eu
+
 apt-get install -y --no-install-recommends \
-  busybox-static \
-  ruby
+  busybox-static
 
 cd /tmp
 busybox wget https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb
-echo "96625d97354c1cc905a8630f3d715f64b14bc5b89f3e30913d2eb02da3a01f20a7784d32c2ed340ca401dce4d1bc0e6bebfc3fbb3808725225c5793b16fa6ef4 /tmp/machine-guest-tools_riscv64.deb" \
-  | sha512sum -c
-apt-get install -y --no-install-recommends \
-  /tmp/machine-guest-tools_riscv64.deb
+sha512sum -c /tmp/machine-guest-tools_riscv64.deb.sha512sum
+
+apt-get install -y --no-install-recommends /tmp/machine-guest-tools_riscv64.deb
 rm /tmp/machine-guest-tools_riscv64.deb
 
 # Fix non-determinism issue when installing machine-guest-tools
 cp -a /etc/shadow /etc/shadow-
 
+# Strip non-determinism
 rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
+apt-get dist-clean
 EOF
 
 ENV PATH="/opt/cartesi/bin:${PATH}"
 
-# Copy over gems from the dependencies stage
-COPY --from=builder /var/lib/gems/ /var/lib/gems/
+# Copy over gems from the builder stage
+COPY --from=builder /usr/local/bundle /usr/local/bundle
 
-WORKDIR /usr/src/app
+WORKDIR /opt/cartesi/dapp
 COPY . .
+
+ENV ROLLUP_HTTP_SERVER_URL="http://127.0.0.1:5004"
 
 ENTRYPOINT ["rollup-init"]
 CMD ["ruby", "main.rb"]

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -2,109 +2,114 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG UBUNTU_TAG=noble-20250910
-ARG APT_UPDATE_SNAPSHOT=20250915T030400Z
+ARG APT_UPDATE_SNAPSHOT=20250908T144407Z
+ARG DEBIAN_TAG=trixie-20250908-slim@sha256:c2880112cc5c61e1200c26f106e4123627b49726375eb5846313da9cca117337
+ARG RUST_VERSION=1.89
 
-################################################################################
-# riscv64 base stage
-FROM --platform=linux/riscv64 ubuntu:${UBUNTU_TAG} AS base-riscv64
-
+# Configure apt to use snapshot.debian.org
+FROM scratch AS apt-config
 ARG APT_UPDATE_SNAPSHOT
-ARG DEBIAN_FRONTEND=noninteractive
-RUN <<EOF
-set -eu
-apt-get update
-apt-get install -y --no-install-recommends ca-certificates curl
-apt-get update --snapshot=${APT_UPDATE_SNAPSHOT}
+COPY <<EOF /etc/apt/sources.list.d/debian.sources
+Types: deb
+URIs: http://snapshot.debian.org/archive/debian/${APT_UPDATE_SNAPSHOT}
+Suites: trixie trixie-updates
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+
+Types: deb
+URIs: http://snapshot.debian.org/archive/debian-security/${APT_UPDATE_SNAPSHOT}
+Suites: trixie-security
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+EOF
+
+# Configure apt to accept snapshots for expired suites (security, updates)
+COPY <<EOF /etc/apt/apt.conf.d/10-nocheckvalid
+Acquire::Check-Valid-Until false;
+EOF
+
+# Configure apt to Ignore TLS verify on first apt-get update --snapshot=
+COPY <<EOF /etc/apt/apt.conf.d/99-insecure
+Acquire::https::Verify-Peer false;
+Acquire::https::Verify-Host false;
 EOF
 
 ################################################################################
-# cross base stage
-FROM --platform=$BUILDPLATFORM ubuntu:${UBUNTU_TAG} AS base-cross
+# riscv64 base stage
+FROM --platform=linux/riscv64 debian:${DEBIAN_TAG} AS base
 
-ARG APT_UPDATE_SNAPSHOT
+COPY --link --from=apt-config / /
+
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
-set -eu
+set -e
+
 apt-get update
-apt-get install -y --no-install-recommends ca-certificates curl
-apt-get update --snapshot=${APT_UPDATE_SNAPSHOT}
+apt-get install -y --no-install-recommends \
+    ca-certificates
 EOF
 
 ################################################################################
 # cross build stage
-FROM base-cross AS cross-build-stage
+FROM --platform=$BUILDPLATFORM rust:${RUST_VERSION}-slim-trixie AS cross-builder
 
-ENV RUSTUP_HOME=/usr/local/rustup \
-    CARGO_HOME=/usr/local/cargo \
-    PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.82.0
+COPY --link --from=apt-config / /
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
+apt-get update
 apt-get install -y --no-install-recommends \
     build-essential \
+    ca-certificates \
     g++-riscv64-linux-gnu
 EOF
 
-RUN <<EOF
-set -eux
-dpkgArch="$(dpkg --print-architecture)"
-case "${dpkgArch##*-}" in \
-    amd64) rustArch='x86_64-unknown-linux-gnu'; rustupSha256='6aeece6993e902708983b209d04c0d1dbb14ebb405ddb87def578d41f920f56d' ;;
-    armhf) rustArch='armv7-unknown-linux-gnueabihf'; rustupSha256='3c4114923305f1cd3b96ce3454e9e549ad4aa7c07c03aec73d1a785e98388bed' ;;
-    arm64) rustArch='aarch64-unknown-linux-gnu'; rustupSha256='1cffbf51e63e634c746f741de50649bbbcbd9dbe1de363c9ecef64e278dba2b2' ;;
-    i386) rustArch='i686-unknown-linux-gnu'; rustupSha256='0a6bed6e9f21192a51f83977716466895706059afb880500ff1d0e751ada5237' ;;
-    *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;;
-esac
-url="https://static.rust-lang.org/rustup/archive/1.27.1/${rustArch}/rustup-init"
-curl -fsSL -O "$url"
-echo "${rustupSha256} *rustup-init" | sha256sum -c -
-chmod +x rustup-init
-./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch}
-rm rustup-init
-chmod -R a+w $RUSTUP_HOME $CARGO_HOME
-rustup --version
-cargo --version
-rustc --version
-EOF
-
-RUN rustup target add riscv64gc-unknown-linux-gnu
-
 WORKDIR /opt/cartesi/dapp
 COPY . .
-RUN cargo build --release
+
+RUN <<EOF
+set -e
+rustup target add riscv64gc-unknown-linux-gnu
+cargo build --release
+EOF
 
 ################################################################################
 # runtime stage: produces final image that will be executed
-FROM base-riscv64
+FROM base
+RUN rm /etc/apt/apt.conf.d/99-insecure
+
+COPY <<EOF /tmp/machine-guest-tools_riscv64.deb.sha512sum
+96625d97354c1cc905a8630f3d715f64b14bc5b89f3e30913d2eb02da3a01f20a7784d32c2ed340ca401dce4d1bc0e6bebfc3fbb3808725225c5793b16fa6ef4 /tmp/machine-guest-tools_riscv64.deb
+EOF
 
 ARG MACHINE_GUEST_TOOLS_VERSION=0.17.1
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
-set -e
+set -eu
+
 apt-get install -y --no-install-recommends \
-    busybox-static
+  busybox-static
 
 cd /tmp
 busybox wget https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb
-echo "96625d97354c1cc905a8630f3d715f64b14bc5b89f3e30913d2eb02da3a01f20a7784d32c2ed340ca401dce4d1bc0e6bebfc3fbb3808725225c5793b16fa6ef4 /tmp/machine-guest-tools_riscv64.deb" \
-    | sha512sum -c
-apt-get install -y --no-install-recommends \
-    /tmp/machine-guest-tools_riscv64.deb
+sha512sum -c /tmp/machine-guest-tools_riscv64.deb.sha512sum
+
+apt-get install -y --no-install-recommends /tmp/machine-guest-tools_riscv64.deb
 rm /tmp/machine-guest-tools_riscv64.deb
 
 # Fix non-determinism issue when installing machine-guest-tools
 cp -a /etc/shadow /etc/shadow-
 
+# Strip non-determinism
 rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
+apt-get dist-clean
 EOF
 
 ENV PATH="/opt/cartesi/bin:/opt/cartesi/dapp:${PATH}"
 
 WORKDIR /opt/cartesi/dapp
-COPY --from=cross-build-stage /opt/cartesi/dapp/target/riscv64gc-unknown-linux-gnu/release/dapp .
+COPY --from=cross-builder /opt/cartesi/dapp/target/riscv64gc-unknown-linux-gnu/release/dapp .
 
 ENV ROLLUP_HTTP_SERVER_URL="http://127.0.0.1:5004"
 


### PR DESCRIPTION
This pull request modernizes and hardens the Dockerfiles for all supported languages by switching from Ubuntu to Debian "trixie" base images, introducing reproducible builds using snapshot.debian.org, and improving the installation process for `machine-guest-tools`. It also includes several clean-up and security enhancements, such as stricter verification of downloaded packages and improved build determinism.

**Base image and build reproducibility improvements:**

* All Dockerfiles (`cpp-low-level/Dockerfile`, `cpp/Dockerfile`, `go/Dockerfile`, `lua/Dockerfile`, `python/Dockerfile`) now use Debian "trixie" snapshot images instead of Ubuntu, with apt configured to use snapshot.debian.org for fully reproducible builds. Custom apt configs are added to handle expired snapshots and insecure TLS for the initial update. [[1]](diffhunk://#diff-4ce5ed242867709da66b465542643f5c4d0f37ca663a2543263c150a50dde2c0L2-R61) [[2]](diffhunk://#diff-3a4cf0094e745eb8d6156c50a7cc2f5c2bfeac389a9d1477f08320a0253891ceL5-R54) [[3]](diffhunk://#diff-e7c951435e49f58cbf8ae82360edd2a5fa60f2d369a01a37abac831d84cdc88dL5-R113) [[4]](diffhunk://#diff-568a58385ab1ea65860e040bbfe1241f0cd1f28cdbb6884862844dfc89ede316L5-R54) [[5]](diffhunk://#diff-c4c9f41a561e18e28581e72d6e45de6aa258c28df8bcb6dad2241ac174d11185L5-R104)

**Machine guest tools installation and verification:**

* The installation of `machine-guest-tools` is now performed in a more secure and reproducible way: a SHA512 checksum file is injected and verified before installing the downloaded `.deb` package, and the process is unified across all Dockerfiles. [[1]](diffhunk://#diff-4ce5ed242867709da66b465542643f5c4d0f37ca663a2543263c150a50dde2c0L36-R91) [[2]](diffhunk://#diff-3a4cf0094e745eb8d6156c50a7cc2f5c2bfeac389a9d1477f08320a0253891ceR74-R100) [[3]](diffhunk://#diff-e7c951435e49f58cbf8ae82360edd2a5fa60f2d369a01a37abac831d84cdc88dL5-R113) [[4]](diffhunk://#diff-568a58385ab1ea65860e040bbfe1241f0cd1f28cdbb6884862844dfc89ede316R72-R111) [[5]](diffhunk://#diff-c4c9f41a561e18e28581e72d6e45de6aa258c28df8bcb6dad2241ac174d11185L5-R104)

**Build and runtime environment clean-up:**

* All images now explicitly remove temporary apt configs and aggressively clean up package manager caches, logs, and other non-deterministic files. A new `apt-get dist-clean` step is added to further strip non-determinism from the final images. [[1]](diffhunk://#diff-4ce5ed242867709da66b465542643f5c4d0f37ca663a2543263c150a50dde2c0L36-R91) [[2]](diffhunk://#diff-3a4cf0094e745eb8d6156c50a7cc2f5c2bfeac389a9d1477f08320a0253891ceR74-R100) [[3]](diffhunk://#diff-e7c951435e49f58cbf8ae82360edd2a5fa60f2d369a01a37abac831d84cdc88dL5-R113) [[4]](diffhunk://#diff-568a58385ab1ea65860e040bbfe1241f0cd1f28cdbb6884862844dfc89ede316R72-R111) [[5]](diffhunk://#diff-c4c9f41a561e18e28581e72d6e45de6aa258c28df8bcb6dad2241ac174d11185L5-R104)

**Language-specific improvements:**

* The Python Dockerfile now builds and copies a virtual environment in a dedicated builder stage, sets the correct `PATH`, and runs as a non-root user (`dapp`).
* The Go Dockerfile uses the official `golang` image for cross-building, simplifying the build process and removing manual installation of Go.
* The Lua Dockerfile splits the installation of Lua dependencies and system libraries for better layering and reproducibility. [[1]](diffhunk://#diff-568a58385ab1ea65860e040bbfe1241f0cd1f28cdbb6884862844dfc89ede316L33) [[2]](diffhunk://#diff-568a58385ab1ea65860e040bbfe1241f0cd1f28cdbb6884862844dfc89ede316R72-R111)

**.dockerignore updates:**

* Added `.cartesi`, `.venv`, `.bundle` to `.dockerignore` files to prevent local development artifacts from being included in Docker build contexts. [[1]](diffhunk://#diff-5eba8835180cd292c2544fb91f7701e763187910fa8d7e0f2f4605e6360a2789R1-R2) [[2]](diffhunk://#diff-1d20ffb5e6ad7c954cf60ca259a1753ee73ef5fd3c131ae8ff3d322819170028R2)

These changes collectively improve security, reproducibility, and maintainability of the build process for all supported languages.