### PR TITLE
chore: bump ubuntu baseimage to noble-20250805

### DIFF
--- a/cpp-low-level/Dockerfile
+++ b/cpp-low-level/Dockerfile
@@ -3,8 +3,8 @@ ARG MACHINE_GUEST_TOOLS_VERSION=0.17.1
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG UBUNTU_TAG=noble-20250529
-ARG APT_UPDATE_SNAPSHOT=20250601T030400Z
+ARG UBUNTU_TAG=noble-20250805
+ARG APT_UPDATE_SNAPSHOT=20250901T030400Z
 
 ################################################################################
 # riscv64 base stage

--- a/cpp/Dockerfile
+++ b/cpp/Dockerfile
@@ -2,8 +2,8 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG UBUNTU_TAG=noble-20250529
-ARG APT_UPDATE_SNAPSHOT=20250601T030400Z
+ARG UBUNTU_TAG=noble-20250805
+ARG APT_UPDATE_SNAPSHOT=20250901T030400Z
 
 ################################################################################
 # riscv64 base stage

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -2,8 +2,8 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG UBUNTU_TAG=noble-20250529
-ARG APT_UPDATE_SNAPSHOT=20250601T030400Z
+ARG UBUNTU_TAG=noble-20250805
+ARG APT_UPDATE_SNAPSHOT=20250901T030400Z
 
 ################################################################################
 # riscv64 base stage

--- a/javascript/Dockerfile
+++ b/javascript/Dockerfile
@@ -2,7 +2,7 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG APT_UPDATE_SNAPSHOT=20250424T030400Z
+ARG APT_UPDATE_SNAPSHOT=20250901T030400Z
 
 ################################################################################
 # riscv64 base stage

--- a/lua/Dockerfile
+++ b/lua/Dockerfile
@@ -2,8 +2,8 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG UBUNTU_TAG=noble-20250529
-ARG APT_UPDATE_SNAPSHOT=20250601T030400Z
+ARG UBUNTU_TAG=noble-20250805
+ARG APT_UPDATE_SNAPSHOT=20250901T030400Z
 
 ################################################################################
 # riscv64 base stage

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -2,7 +2,7 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG APT_UPDATE_SNAPSHOT=20250424T030400Z
+ARG APT_UPDATE_SNAPSHOT=20250901T030400Z
 
 ################################################################################
 # riscv64 base stage

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -2,8 +2,8 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG UBUNTU_TAG=noble-20250529
-ARG APT_UPDATE_SNAPSHOT=20250601T030400Z
+ARG UBUNTU_TAG=noble-20250805
+ARG APT_UPDATE_SNAPSHOT=20250901T030400Z
 
 ################################################################################
 # riscv64 base stage

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -2,8 +2,8 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG UBUNTU_TAG=noble-20250529
-ARG APT_UPDATE_SNAPSHOT=20250601T030400Z
+ARG UBUNTU_TAG=noble-20250805
+ARG APT_UPDATE_SNAPSHOT=20250901T030400Z
 
 ################################################################################
 # riscv64 base stage

--- a/typescript/Dockerfile
+++ b/typescript/Dockerfile
@@ -2,7 +2,7 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG APT_UPDATE_SNAPSHOT=20250424T030400Z
+ARG APT_UPDATE_SNAPSHOT=20250901T030400Z
 
 ################################################################################
 # riscv64 base stage


### PR DESCRIPTION
Replaces : #67

Reference: https://github.com/docker-library/official-images/pull/19791