### PR TITLE
Ci/update ci cli

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,5 +43,17 @@ jobs:
         run: cartesi doctor
 
       - name: Build ${{ matrix.template }}
-        run: cartesi build
+        run: cartesi build --debug
         working-directory: ${{ matrix.template }}
+
+      - name: Print cartesi-machine hash
+        run: cartesi hash
+        working-directory: ${{ matrix.template }}
+
+      - name: Upload root.ext2 artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.template }}-rootfs
+          path: |
+            ${{ matrix.template }}/.cartesi/root.ext2
+            ${{ matrix.template }}/.cartesi/root.tar

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,7 +34,7 @@ jobs:
           node-version: current
 
       - name: Install Cartesi CLI
-        run: npm install -g @cartesi/cli@2.0.0-alpha.8
+        run: npm install -g @cartesi/cli@2.0.0-alpha.18
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
This pull request updates the build workflow to use a newer version of the Cartesi CLI and adds steps to improve build traceability and artifact management. The most important changes are:

**Build tooling updates:**

* Updated the Cartesi CLI version from `2.0.0-alpha.8` to `2.0.0-alpha.17` in the GitHub Actions workflow to ensure compatibility with the latest features and bug fixes.

**Build process improvements:**

* Added a step to print the `cartesi-machine` hash after building each template, which helps with traceability and debugging.

**Artifact management:**

* Added a step to upload the `root.ext2` file as a build artifact for each template, making it easier to access build outputs from the workflow.