### PR TITLE
chore: bump ubuntu baseimage to noble-20250925

### DIFF
--- a/cpp-low-level/Dockerfile
+++ b/cpp-low-level/Dockerfile
@@ -3,8 +3,8 @@ ARG MACHINE_GUEST_TOOLS_VERSION=0.17.1
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG UBUNTU_TAG=noble-20250910
-ARG APT_UPDATE_SNAPSHOT=20250915T030400Z
+ARG UBUNTU_TAG=noble-20250925
+ARG APT_UPDATE_SNAPSHOT=20251001T030400Z
 
 ################################################################################
 # riscv64 base stage

--- a/cpp/Dockerfile
+++ b/cpp/Dockerfile
@@ -2,8 +2,8 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG UBUNTU_TAG=noble-20250910
-ARG APT_UPDATE_SNAPSHOT=20250915T030400Z
+ARG UBUNTU_TAG=noble-20250925
+ARG APT_UPDATE_SNAPSHOT=20251001T030400Z
 
 ################################################################################
 # riscv64 base stage

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -2,8 +2,8 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG UBUNTU_TAG=noble-20250910
-ARG APT_UPDATE_SNAPSHOT=20250915T030400Z
+ARG UBUNTU_TAG=noble-20250925
+ARG APT_UPDATE_SNAPSHOT=20251001T030400Z
 
 ################################################################################
 # riscv64 base stage

--- a/lua/Dockerfile
+++ b/lua/Dockerfile
@@ -2,8 +2,8 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG UBUNTU_TAG=noble-20250910
-ARG APT_UPDATE_SNAPSHOT=20250915T030400Z
+ARG UBUNTU_TAG=noble-20250925
+ARG APT_UPDATE_SNAPSHOT=20251001T030400Z
 
 ################################################################################
 # riscv64 base stage

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -2,8 +2,8 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG UBUNTU_TAG=noble-20250910
-ARG APT_UPDATE_SNAPSHOT=20250915T030400Z
+ARG UBUNTU_TAG=noble-20250925
+ARG APT_UPDATE_SNAPSHOT=20251001T030400Z
 
 ################################################################################
 # riscv64 base stage

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -2,8 +2,8 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG UBUNTU_TAG=noble-20250910
-ARG APT_UPDATE_SNAPSHOT=20250915T030400Z
+ARG UBUNTU_TAG=noble-20250925
+ARG APT_UPDATE_SNAPSHOT=20251001T030400Z
 
 ################################################################################
 # riscv64 base stage


### PR DESCRIPTION
This pull request updates the Ubuntu snapshot tags and APT update snapshot dates across multiple Dockerfiles to use newer snapshots. This ensures that the Docker images are built with up-to-date and consistent package versions.

Dockerfile base image updates:

* Updated `UBUNTU_TAG` and `APT_UPDATE_SNAPSHOT` to `noble-20250925` and `20251001T030400Z` respectively in the following Dockerfiles:
  * `cpp-low-level/Dockerfile`
  * `cpp/Dockerfile`
  * `go/Dockerfile`
  * `lua/Dockerfile`
  * `ruby/Dockerfile`
  * `rust/Dockerfile`