### PR TITLE
chore: bump ubuntu baseimage to noble-20251001

### DIFF
--- a/cpp-low-level/Dockerfile
+++ b/cpp-low-level/Dockerfile
@@ -3,8 +3,8 @@ ARG MACHINE_GUEST_TOOLS_VERSION=0.17.1
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG UBUNTU_TAG=noble-20250910
-ARG APT_UPDATE_SNAPSHOT=20250915T030400Z
+ARG UBUNTU_TAG=noble-20251001
+ARG APT_UPDATE_SNAPSHOT=20251009T030400Z
 
 ################################################################################
 # riscv64 base stage

--- a/cpp/Dockerfile
+++ b/cpp/Dockerfile
@@ -2,8 +2,8 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG UBUNTU_TAG=noble-20250910
-ARG APT_UPDATE_SNAPSHOT=20250915T030400Z
+ARG UBUNTU_TAG=noble-20251001
+ARG APT_UPDATE_SNAPSHOT=20251009T030400Z
 
 ################################################################################
 # riscv64 base stage

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -2,8 +2,8 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG UBUNTU_TAG=noble-20250910
-ARG APT_UPDATE_SNAPSHOT=20250915T030400Z
+ARG UBUNTU_TAG=noble-20251001
+ARG APT_UPDATE_SNAPSHOT=20251009T030400Z
 
 ################################################################################
 # riscv64 base stage

--- a/javascript/Dockerfile
+++ b/javascript/Dockerfile
@@ -2,7 +2,7 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG APT_UPDATE_SNAPSHOT=20250915T030400Z
+ARG APT_UPDATE_SNAPSHOT=20251009T030400Z
 
 ################################################################################
 # riscv64 base stage

--- a/lua/Dockerfile
+++ b/lua/Dockerfile
@@ -2,8 +2,8 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG UBUNTU_TAG=noble-20250910
-ARG APT_UPDATE_SNAPSHOT=20250915T030400Z
+ARG UBUNTU_TAG=noble-20251001
+ARG APT_UPDATE_SNAPSHOT=20251009T030400Z
 
 ################################################################################
 # riscv64 base stage

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -2,7 +2,7 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG APT_UPDATE_SNAPSHOT=20250915T030400Z
+ARG APT_UPDATE_SNAPSHOT=20251009T030400Z
 
 ################################################################################
 # riscv64 base stage

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -2,8 +2,8 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG UBUNTU_TAG=noble-20250910
-ARG APT_UPDATE_SNAPSHOT=20250915T030400Z
+ARG UBUNTU_TAG=noble-20251001
+ARG APT_UPDATE_SNAPSHOT=20251009T030400Z
 
 ################################################################################
 # riscv64 base stage

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -2,8 +2,8 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG UBUNTU_TAG=noble-20250910
-ARG APT_UPDATE_SNAPSHOT=20250915T030400Z
+ARG UBUNTU_TAG=noble-20251001
+ARG APT_UPDATE_SNAPSHOT=20251009T030400Z
 
 ################################################################################
 # riscv64 base stage

--- a/typescript/Dockerfile
+++ b/typescript/Dockerfile
@@ -2,7 +2,7 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG APT_UPDATE_SNAPSHOT=20250915T030400Z
+ARG APT_UPDATE_SNAPSHOT=20251009T030400Z
 
 ################################################################################
 # riscv64 base stage


### PR DESCRIPTION
This pull request updates the Ubuntu snapshot versions used in the Dockerfiles across multiple language environments. The main goal is to ensure that all builds use the latest consistent package versions by bumping the `UBUNTU_TAG` and `APT_UPDATE_SNAPSHOT` arguments.

**Dockerfile snapshot updates:**

* Updated `UBUNTU_TAG` and `APT_UPDATE_SNAPSHOT` to `noble-20251001` and `20251009T030400Z` respectively in the following Dockerfiles: `cpp-low-level/Dockerfile`, `cpp/Dockerfile`, `go/Dockerfile`, `lua/Dockerfile`, `ruby/Dockerfile`, and `rust/Dockerfile`. [[1]](diffhunk://#diff-4ce5ed242867709da66b465542643f5c4d0f37ca663a2543263c150a50dde2c0L6-R7) [[2]](diffhunk://#diff-3a4cf0094e745eb8d6156c50a7cc2f5c2bfeac389a9d1477f08320a0253891ceL5-R6) [[3]](diffhunk://#diff-e7c951435e49f58cbf8ae82360edd2a5fa60f2d369a01a37abac831d84cdc88dL5-R6) [[4]](diffhunk://#diff-568a58385ab1ea65860e040bbfe1241f0cd1f28cdbb6884862844dfc89ede316L5-R6) [[5]](diffhunk://#diff-4b62900532c579e3c7c952ed7e68a5614cfb8f35adf4640c4523c54fd3e29271L5-R6) [[6]](diffhunk://#diff-f70412486b2e4b00416a0b6ec8862d81e3d8d15b0a89f10501881f8bb6ebc8d6L5-R6)
* Updated only `APT_UPDATE_SNAPSHOT` to `20251009T030400Z` in the following Dockerfiles: `javascript/Dockerfile`, `python/Dockerfile`, and `typescript/Dockerfile`. [[1]](diffhunk://#diff-f408b8e465d2b31e38dd296f380471a4e92cb16483dbd7a47fba9a6c18fbcb80L5-R5) [[2]](diffhunk://#diff-c4c9f41a561e18e28581e72d6e45de6aa258c28df8bcb6dad2241ac174d11185L5-R5) [[3]](diffhunk://#diff-7d153ffddf01fb102b3224097d467d3ffaa668fc9b251be2a4050061aea40305L5-R5)