### PR TITLE
chore: bump machine-guest-tools to 0.17.2

### DIFF
--- a/cpp-low-level/Dockerfile
+++ b/cpp-low-level/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker.io/docker/dockerfile:1
-ARG MACHINE_GUEST_TOOLS_VERSION=0.17.1
+ARG MACHINE_GUEST_TOOLS_VERSION=0.17.2
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
@@ -41,7 +41,7 @@ ADD https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_
 
 RUN <<EOF
 set -e
-echo "96625d97354c1cc905a8630f3d715f64b14bc5b89f3e30913d2eb02da3a01f20a7784d32c2ed340ca401dce4d1bc0e6bebfc3fbb3808725225c5793b16fa6ef4 /tmp/machine-guest-tools_riscv64.deb" \
+echo "4af9911a5a76738d526bfc2b5462cf96c9dee98ec8b23f3ca91ac4849d5761765f471b5e2e8779809bc4a26d2799f8e744622864fa549ada5941e21d999ff4be /tmp/machine-guest-tools_riscv64.deb" \
   | sha512sum -c
 apt-get install -y --no-install-recommends \
   /tmp/machine-guest-tools_riscv64.deb
@@ -65,14 +65,11 @@ apt-get install -y --no-install-recommends \
 
 cd /tmp
 busybox wget https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb
-echo "96625d97354c1cc905a8630f3d715f64b14bc5b89f3e30913d2eb02da3a01f20a7784d32c2ed340ca401dce4d1bc0e6bebfc3fbb3808725225c5793b16fa6ef4 /tmp/machine-guest-tools_riscv64.deb" \
+echo "4af9911a5a76738d526bfc2b5462cf96c9dee98ec8b23f3ca91ac4849d5761765f471b5e2e8779809bc4a26d2799f8e744622864fa549ada5941e21d999ff4be /tmp/machine-guest-tools_riscv64.deb" \
   | sha512sum -c
 apt-get install -y --no-install-recommends \
   /tmp/machine-guest-tools_riscv64.deb
 rm /tmp/machine-guest-tools_riscv64.deb
-
-# Fix non-determinism issue when installing machine-guest-tools
-cp -a /etc/shadow /etc/shadow-
 
 rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
 EOF

--- a/cpp/Dockerfile
+++ b/cpp/Dockerfile
@@ -41,7 +41,7 @@ RUN make
 # runtime stage: produces final image that will be executed
 FROM base
 
-ARG MACHINE_GUEST_TOOLS_VERSION=0.17.1
+ARG MACHINE_GUEST_TOOLS_VERSION=0.17.2
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
@@ -50,14 +50,11 @@ apt-get install -y --no-install-recommends \
 
 cd /tmp
 busybox wget https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb
-echo "96625d97354c1cc905a8630f3d715f64b14bc5b89f3e30913d2eb02da3a01f20a7784d32c2ed340ca401dce4d1bc0e6bebfc3fbb3808725225c5793b16fa6ef4 /tmp/machine-guest-tools_riscv64.deb" \
+echo "4af9911a5a76738d526bfc2b5462cf96c9dee98ec8b23f3ca91ac4849d5761765f471b5e2e8779809bc4a26d2799f8e744622864fa549ada5941e21d999ff4be /tmp/machine-guest-tools_riscv64.deb" \
   | sha512sum -c
 apt-get install -y --no-install-recommends \
   /tmp/machine-guest-tools_riscv64.deb
 rm /tmp/machine-guest-tools_riscv64.deb
-
-# Fix non-determinism issue when installing machine-guest-tools
-cp -a /etc/shadow /etc/shadow-
 
 rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
 EOF

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -65,7 +65,7 @@ RUN make
 # runtime stage: produces final image that will be executed
 FROM base-riscv64
 
-ARG MACHINE_GUEST_TOOLS_VERSION=0.17.1
+ARG MACHINE_GUEST_TOOLS_VERSION=0.17.2
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
@@ -74,14 +74,11 @@ apt-get install -y --no-install-recommends \
 
 cd /tmp
 busybox wget https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb
-echo "96625d97354c1cc905a8630f3d715f64b14bc5b89f3e30913d2eb02da3a01f20a7784d32c2ed340ca401dce4d1bc0e6bebfc3fbb3808725225c5793b16fa6ef4 /tmp/machine-guest-tools_riscv64.deb" \
+echo "4af9911a5a76738d526bfc2b5462cf96c9dee98ec8b23f3ca91ac4849d5761765f471b5e2e8779809bc4a26d2799f8e744622864fa549ada5941e21d999ff4be /tmp/machine-guest-tools_riscv64.deb" \
   | sha512sum -c
 apt-get install -y --no-install-recommends \
   /tmp/machine-guest-tools_riscv64.deb
 rm /tmp/machine-guest-tools_riscv64.deb
-
-# Fix non-determinism issue when installing machine-guest-tools
-cp -a /etc/shadow /etc/shadow-
 
 rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
 EOF

--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -16,16 +16,15 @@ COPY app/src /app/app/src
 
 RUN ./gradlew --no-daemon shadowJar
 
-
 # ################################################################################
 # # Runtime stage (Cartesi-compatible: linux/riscv64)
-
 FROM --platform=linux/riscv64 eclipse-temurin:21-jre
 
 ARG MACHINE_GUEST_TOOLS_VERSION=0.17.2
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
+apt-get update
 apt-get install -y --no-install-recommends \
   busybox-static
 
@@ -43,7 +42,6 @@ EOF
 # Copy built JAR from Stage 1
 WORKDIR /opt/cartesi/dapp
 COPY --from=build /app/app/build/libs/app.jar ./app.jar
-
 
 ENV PATH="/opt/cartesi/bin:${PATH}"
 ENV ROLLUP_HTTP_SERVER_URL="http://127.0.0.1:5004"

--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -22,15 +22,23 @@ RUN ./gradlew --no-daemon shadowJar
 
 FROM --platform=linux/riscv64 eclipse-temurin:21-jre
 
-ARG MACHINE_GUEST_TOOLS_VERSION=0.17.0
-RUN apt-get update && \
-  apt-get install -y --no-install-recommends wget && \
-  wget -O /tmp/tools.deb https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb && \
-  echo "973943b3a3e40164175da7d7b5b7857642d1277e1fd38be268da12daca5ff458735f93a7ac25b350b3de58b073a25b64c860d9eb92157bfc946b03dd1a345cc9 /tmp/tools.deb" | sha512sum -c && \
-  apt-get install -y /tmp/tools.deb && \
-  rm -f /tmp/tools.deb && \
-  cp -a /etc/shadow /etc/shadow- && \
-  rm -rf /var/lib/apt/lists/*
+ARG MACHINE_GUEST_TOOLS_VERSION=0.17.2
+ARG DEBIAN_FRONTEND=noninteractive
+RUN <<EOF
+set -e
+apt-get install -y --no-install-recommends \
+  busybox-static
+
+cd /tmp
+busybox wget https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb
+echo "4af9911a5a76738d526bfc2b5462cf96c9dee98ec8b23f3ca91ac4849d5761765f471b5e2e8779809bc4a26d2799f8e744622864fa549ada5941e21d999ff4be /tmp/machine-guest-tools_riscv64.deb" \
+  | sha512sum -c
+apt-get install -y --no-install-recommends \
+  /tmp/machine-guest-tools_riscv64.deb
+rm /tmp/machine-guest-tools_riscv64.deb
+
+rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
+EOF
 
 # Copy built JAR from Stage 1
 WORKDIR /opt/cartesi/dapp

--- a/javascript/Dockerfile
+++ b/javascript/Dockerfile
@@ -40,7 +40,7 @@ RUN yarn build
 # performance when loading the Cartesi Machine.
 FROM base
 
-ARG MACHINE_GUEST_TOOLS_VERSION=0.17.1
+ARG MACHINE_GUEST_TOOLS_VERSION=0.17.2
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
@@ -50,14 +50,11 @@ apt-get install -y --no-install-recommends \
 
 cd /tmp
 busybox wget https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb
-echo "96625d97354c1cc905a8630f3d715f64b14bc5b89f3e30913d2eb02da3a01f20a7784d32c2ed340ca401dce4d1bc0e6bebfc3fbb3808725225c5793b16fa6ef4 /tmp/machine-guest-tools_riscv64.deb" \
+echo "4af9911a5a76738d526bfc2b5462cf96c9dee98ec8b23f3ca91ac4849d5761765f471b5e2e8779809bc4a26d2799f8e744622864fa549ada5941e21d999ff4be /tmp/machine-guest-tools_riscv64.deb" \
   | sha512sum -c
 apt-get install -y --no-install-recommends \
   /tmp/machine-guest-tools_riscv64.deb
 rm /tmp/machine-guest-tools_riscv64.deb
-
-# Fix non-determinism issue when installing machine-guest-tools
-cp -a /etc/shadow /etc/shadow-
 
 rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
 EOF

--- a/lua/Dockerfile
+++ b/lua/Dockerfile
@@ -40,7 +40,7 @@ EOF
 # riscv64 final stage
 FROM base
 
-ARG MACHINE_GUEST_TOOLS_VERSION=0.17.1
+ARG MACHINE_GUEST_TOOLS_VERSION=0.17.2
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
@@ -51,14 +51,11 @@ apt-get install -y --no-install-recommends \
 
 cd /tmp
 busybox wget https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb
-echo "96625d97354c1cc905a8630f3d715f64b14bc5b89f3e30913d2eb02da3a01f20a7784d32c2ed340ca401dce4d1bc0e6bebfc3fbb3808725225c5793b16fa6ef4 /tmp/machine-guest-tools_riscv64.deb" \
+echo "4af9911a5a76738d526bfc2b5462cf96c9dee98ec8b23f3ca91ac4849d5761765f471b5e2e8779809bc4a26d2799f8e744622864fa549ada5941e21d999ff4be /tmp/machine-guest-tools_riscv64.deb" \
   | sha512sum -c
 apt-get install -y --no-install-recommends \
   /tmp/machine-guest-tools_riscv64.deb
 rm /tmp/machine-guest-tools_riscv64.deb
-
-# Fix non-determinism issue when installing machine-guest-tools
-cp -a /etc/shadow /etc/shadow-
 
 rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
 EOF

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -25,7 +25,7 @@ EOF
 # performance when loading the Cartesi Machine.
 FROM base
 
-ARG MACHINE_GUEST_TOOLS_VERSION=0.17.1
+ARG MACHINE_GUEST_TOOLS_VERSION=0.17.2
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
@@ -34,14 +34,11 @@ apt-get install -y --no-install-recommends \
 
 cd /tmp
 busybox wget https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb
-echo "96625d97354c1cc905a8630f3d715f64b14bc5b89f3e30913d2eb02da3a01f20a7784d32c2ed340ca401dce4d1bc0e6bebfc3fbb3808725225c5793b16fa6ef4 /tmp/machine-guest-tools_riscv64.deb" \
+echo "4af9911a5a76738d526bfc2b5462cf96c9dee98ec8b23f3ca91ac4849d5761765f471b5e2e8779809bc4a26d2799f8e744622864fa549ada5941e21d999ff4be /tmp/machine-guest-tools_riscv64.deb" \
   | sha512sum -c
 apt-get install -y --no-install-recommends \
   /tmp/machine-guest-tools_riscv64.deb
 rm /tmp/machine-guest-tools_riscv64.deb
-
-# Fix non-determinism issue when installing machine-guest-tools
-cp -a /etc/shadow /etc/shadow-
 
 rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
 EOF

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -44,7 +44,7 @@ EOF
 ################################################################################
 # runtime stage: produces final image that will be executed
 FROM base
-ARG MACHINE_GUEST_TOOLS_VERSION=0.17.1
+ARG MACHINE_GUEST_TOOLS_VERSION=0.17.2
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
@@ -54,14 +54,11 @@ apt-get install -y --no-install-recommends \
 
 cd /tmp
 busybox wget https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb
-echo "96625d97354c1cc905a8630f3d715f64b14bc5b89f3e30913d2eb02da3a01f20a7784d32c2ed340ca401dce4d1bc0e6bebfc3fbb3808725225c5793b16fa6ef4 /tmp/machine-guest-tools_riscv64.deb" \
+echo "4af9911a5a76738d526bfc2b5462cf96c9dee98ec8b23f3ca91ac4849d5761765f471b5e2e8779809bc4a26d2799f8e744622864fa549ada5941e21d999ff4be /tmp/machine-guest-tools_riscv64.deb" \
   | sha512sum -c
 apt-get install -y --no-install-recommends \
   /tmp/machine-guest-tools_riscv64.deb
 rm /tmp/machine-guest-tools_riscv64.deb
-
-# Fix non-determinism issue when installing machine-guest-tools
-cp -a /etc/shadow /etc/shadow-
 
 rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
 EOF

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -80,7 +80,7 @@ RUN cargo build --release
 # runtime stage: produces final image that will be executed
 FROM base-riscv64
 
-ARG MACHINE_GUEST_TOOLS_VERSION=0.17.1
+ARG MACHINE_GUEST_TOOLS_VERSION=0.17.2
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
@@ -89,14 +89,11 @@ apt-get install -y --no-install-recommends \
 
 cd /tmp
 busybox wget https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb
-echo "96625d97354c1cc905a8630f3d715f64b14bc5b89f3e30913d2eb02da3a01f20a7784d32c2ed340ca401dce4d1bc0e6bebfc3fbb3808725225c5793b16fa6ef4 /tmp/machine-guest-tools_riscv64.deb" \
+echo "4af9911a5a76738d526bfc2b5462cf96c9dee98ec8b23f3ca91ac4849d5761765f471b5e2e8779809bc4a26d2799f8e744622864fa549ada5941e21d999ff4be /tmp/machine-guest-tools_riscv64.deb" \
     | sha512sum -c
 apt-get install -y --no-install-recommends \
     /tmp/machine-guest-tools_riscv64.deb
 rm /tmp/machine-guest-tools_riscv64.deb
-
-# Fix non-determinism issue when installing machine-guest-tools
-cp -a /etc/shadow /etc/shadow-
 
 rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
 EOF

--- a/typescript/Dockerfile
+++ b/typescript/Dockerfile
@@ -41,7 +41,7 @@ RUN yarn build
 # performance when loading the Cartesi Machine.
 FROM base
 
-ARG MACHINE_GUEST_TOOLS_VERSION=0.17.1
+ARG MACHINE_GUEST_TOOLS_VERSION=0.17.2
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
@@ -50,14 +50,11 @@ apt-get install -y --no-install-recommends \
 
 cd /tmp
 busybox wget https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb
-echo "96625d97354c1cc905a8630f3d715f64b14bc5b89f3e30913d2eb02da3a01f20a7784d32c2ed340ca401dce4d1bc0e6bebfc3fbb3808725225c5793b16fa6ef4 /tmp/machine-guest-tools_riscv64.deb" \
+echo "4af9911a5a76738d526bfc2b5462cf96c9dee98ec8b23f3ca91ac4849d5761765f471b5e2e8779809bc4a26d2799f8e744622864fa549ada5941e21d999ff4be /tmp/machine-guest-tools_riscv64.deb" \
   | sha512sum -c
 apt-get install -y --no-install-recommends \
   /tmp/machine-guest-tools_riscv64.deb
 rm /tmp/machine-guest-tools_riscv64.deb
-
-# Fix non-determinism issue when installing machine-guest-tools
-cp -a /etc/shadow /etc/shadow-
 
 rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
 EOF


### PR DESCRIPTION
This pull request updates the installation of `machine-guest-tools` across all language-specific Dockerfiles to use version 0.17.2. It also updates the expected SHA512 checksum for the downloaded `.deb` package and removes a workaround related to non-determinism in the installation process. The changes ensure consistency and security when building images.

**Dependency Version Updates:**

* Updated the `MACHINE_GUEST_TOOLS_VERSION` argument from previous versions (mostly 0.17.1, 0.17.0 for Java) to `0.17.2` in all Dockerfiles (`cpp-low-level/Dockerfile`, `cpp/Dockerfile`, `go/Dockerfile`, `java/Dockerfile`, `javascript/Dockerfile`, `lua/Dockerfile`, `python/Dockerfile`, `ruby/Dockerfile`, `rust/Dockerfile`, `typescript/Dockerfile`). [[1]](diffhunk://#diff-4ce5ed242867709da66b465542643f5c4d0f37ca663a2543263c150a50dde2c0L2-R2) [[2]](diffhunk://#diff-3a4cf0094e745eb8d6156c50a7cc2f5c2bfeac389a9d1477f08320a0253891ceL44-R44) [[3]](diffhunk://#diff-e7c951435e49f58cbf8ae82360edd2a5fa60f2d369a01a37abac831d84cdc88dL68-R68) [[4]](diffhunk://#diff-2c3cd63eeda6d94e4ac3cc5a0493362bc97cd5f8fa694aea346ee2baf6cec5cbL25-R41) [[5]](diffhunk://#diff-f408b8e465d2b31e38dd296f380471a4e92cb16483dbd7a47fba9a6c18fbcb80L43-R43) [[6]](diffhunk://#diff-568a58385ab1ea65860e040bbfe1241f0cd1f28cdbb6884862844dfc89ede316L43-R43) [[7]](diffhunk://#diff-c4c9f41a561e18e28581e72d6e45de6aa258c28df8bcb6dad2241ac174d11185L28-R28) [[8]](diffhunk://#diff-4b62900532c579e3c7c952ed7e68a5614cfb8f35adf4640c4523c54fd3e29271L47-R47) [[9]](diffhunk://#diff-f70412486b2e4b00416a0b6ec8862d81e3d8d15b0a89f10501881f8bb6ebc8d6L83-R83) [[10]](diffhunk://#diff-7d153ffddf01fb102b3224097d467d3ffaa668fc9b251be2a4050061aea40305L44-R44)

* Updated the SHA512 checksum to match the new version of `machine-guest-tools_riscv64.deb` in all relevant installation steps. [[1]](diffhunk://#diff-4ce5ed242867709da66b465542643f5c4d0f37ca663a2543263c150a50dde2c0L44-R44) [[2]](diffhunk://#diff-4ce5ed242867709da66b465542643f5c4d0f37ca663a2543263c150a50dde2c0L68-L76) [[3]](diffhunk://#diff-3a4cf0094e745eb8d6156c50a7cc2f5c2bfeac389a9d1477f08320a0253891ceL53-L61) [[4]](diffhunk://#diff-e7c951435e49f58cbf8ae82360edd2a5fa60f2d369a01a37abac831d84cdc88dL77-L85) [[5]](diffhunk://#diff-2c3cd63eeda6d94e4ac3cc5a0493362bc97cd5f8fa694aea346ee2baf6cec5cbL25-R41) [[6]](diffhunk://#diff-f408b8e465d2b31e38dd296f380471a4e92cb16483dbd7a47fba9a6c18fbcb80L53-L61) [[7]](diffhunk://#diff-568a58385ab1ea65860e040bbfe1241f0cd1f28cdbb6884862844dfc89ede316L54-L62) [[8]](diffhunk://#diff-c4c9f41a561e18e28581e72d6e45de6aa258c28df8bcb6dad2241ac174d11185L37-L45) [[9]](diffhunk://#diff-4b62900532c579e3c7c952ed7e68a5614cfb8f35adf4640c4523c54fd3e29271L57-L65) [[10]](diffhunk://#diff-f70412486b2e4b00416a0b6ec8862d81e3d8d15b0a89f10501881f8bb6ebc8d6L92-L100) [[11]](diffhunk://#diff-7d153ffddf01fb102b3224097d467d3ffaa668fc9b251be2a4050061aea40305L53-L61)

**Build Process Simplification:**

* Removed the workaround that copied `/etc/shadow` to `/etc/shadow-` after installing `machine-guest-tools` to address non-determinism. This was removed from all Dockerfiles except `cpp-low-level/Dockerfile` (where it was already not present), simplifying the build process. [[1]](diffhunk://#diff-4ce5ed242867709da66b465542643f5c4d0f37ca663a2543263c150a50dde2c0L68-L76) [[2]](diffhunk://#diff-3a4cf0094e745eb8d6156c50a7cc2f5c2bfeac389a9d1477f08320a0253891ceL53-L61) [[3]](diffhunk://#diff-e7c951435e49f58cbf8ae82360edd2a5fa60f2d369a01a37abac831d84cdc88dL77-L85) [[4]](diffhunk://#diff-2c3cd63eeda6d94e4ac3cc5a0493362bc97cd5f8fa694aea346ee2baf6cec5cbL25-R41) [[5]](diffhunk://#diff-f408b8e465d2b31e38dd296f380471a4e92cb16483dbd7a47fba9a6c18fbcb80L53-L61) [[6]](diffhunk://#diff-568a58385ab1ea65860e040bbfe1241f0cd1f28cdbb6884862844dfc89ede316L54-L62) [[7]](diffhunk://#diff-c4c9f41a561e18e28581e72d6e45de6aa258c28df8bcb6dad2241ac174d11185L37-L45) [[8]](diffhunk://#diff-4b62900532c579e3c7c952ed7e68a5614cfb8f35adf4640c4523c54fd3e29271L57-L65) [[9]](diffhunk://#diff-f70412486b2e4b00416a0b6ec8862d81e3d8d15b0a89f10501881f8bb6ebc8d6L92-L100) [[10]](diffhunk://#diff-7d153ffddf01fb102b3224097d467d3ffaa668fc9b251be2a4050061aea40305L53-L61)

**Consistency and Security Improvements:**

* Ensured all Dockerfiles use a consistent method for downloading, verifying, and installing the `machine-guest-tools` package, including the use of `busybox wget` and checksum verification. [[1]](diffhunk://#diff-4ce5ed242867709da66b465542643f5c4d0f37ca663a2543263c150a50dde2c0L44-R44) [[2]](diffhunk://#diff-4ce5ed242867709da66b465542643f5c4d0f37ca663a2543263c150a50dde2c0L68-L76) [[3]](diffhunk://#diff-3a4cf0094e745eb8d6156c50a7cc2f5c2bfeac389a9d1477f08320a0253891ceL53-L61) [[4]](diffhunk://#diff-e7c951435e49f58cbf8ae82360edd2a5fa60f2d369a01a37abac831d84cdc88dL77-L85) [[5]](diffhunk://#diff-2c3cd63eeda6d94e4ac3cc5a0493362bc97cd5f8fa694aea346ee2baf6cec5cbL25-R41) [[6]](diffhunk://#diff-f408b8e465d2b31e38dd296f380471a4e92cb16483dbd7a47fba9a6c18fbcb80L53-L61) [[7]](diffhunk://#diff-568a58385ab1ea65860e040bbfe1241f0cd1f28cdbb6884862844dfc89ede316L54-L62) [[8]](diffhunk://#diff-c4c9f41a561e18e28581e72d6e45de6aa258c28df8bcb6dad2241ac174d11185L37-L45) [[9]](diffhunk://#diff-4b62900532c579e3c7c952ed7e68a5614cfb8f35adf4640c4523c54fd3e29271L57-L65) [[10]](diffhunk://#diff-f70412486b2e4b00416a0b6ec8862d81e3d8d15b0a89f10501881f8bb6ebc8d6L92-L100) [[11]](diffhunk://#diff-7d153ffddf01fb102b3224097d467d3ffaa668fc9b251be2a4050061aea40305L53-L61)

**Platform-specific Adjustments:**

* For the `java/Dockerfile`, switched to a multi-line `RUN <<EOF ... EOF` block for installation to match the approach used in other Dockerfiles, improving maintainability and consistency.

**Cleanup and Optimization:**

* Retained the cleanup steps (`rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*`) after installation to keep images small and free of unnecessary files. [[1]](diffhunk://#diff-4ce5ed242867709da66b465542643f5c4d0f37ca663a2543263c150a50dde2c0L68-L76) [[2]](diffhunk://#diff-3a4cf0094e745eb8d6156c50a7cc2f5c2bfeac389a9d1477f08320a0253891ceL53-L61) [[3]](diffhunk://#diff-e7c951435e49f58cbf8ae82360edd2a5fa60f2d369a01a37abac831d84cdc88dL77-L85) [[4]](diffhunk://#diff-2c3cd63eeda6d94e4ac3cc5a0493362bc97cd5f8fa694aea346ee2baf6cec5cbL25-R41) [[5]](diffhunk://#diff-f408b8e465d2b31e38dd296f380471a4e92cb16483dbd7a47fba9a6c18fbcb80L53-L61) [[6]](diffhunk://#diff-568a58385ab1ea65860e040bbfe1241f0cd1f28cdbb6884862844dfc89ede316L54-L62) [[7]](diffhunk://#diff-c4c9f41a561e18e28581e72d6e45de6aa258c28df8bcb6dad2241ac174d11185L37-L45) [[8]](diffhunk://#diff-4b62900532c579e3c7c952ed7e68a5614cfb8f35adf4640c4523c54fd3e29271L57-L65) [[9]](diffhunk://#diff-f70412486b2e4b00416a0b6ec8862d81e3d8d15b0a89f10501881f8bb6ebc8d6L92-L100) [[10]](diffhunk://#diff-7d153ffddf01fb102b3224097d467d3ffaa668fc9b251be2a4050061aea40305L53-L61)