### PR TITLE
Simplify Dockerfile, bump some versions and reduce final snapshot size

### DIFF
--- a/cpp-low-level/Dockerfile
+++ b/cpp-low-level/Dockerfile
@@ -15,8 +15,10 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -eu
 apt-get update
-apt-get install -y --no-install-recommends ca-certificates curl
+apt-get install -y --no-install-recommends ca-certificates
 apt-get update --snapshot=${APT_UPDATE_SNAPSHOT}
+apt-get remove -y --purge ca-certificates
+apt-get autoremove -y --purge
 EOF
 
 ################################################################################

--- a/cpp-low-level/Dockerfile
+++ b/cpp-low-level/Dockerfile
@@ -1,10 +1,11 @@
 # syntax=docker.io/docker/dockerfile:1
-ARG MACHINE_GUEST_TOOLS_VERSION=0.17.2
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
 ARG UBUNTU_TAG=noble-20250910
 ARG APT_UPDATE_SNAPSHOT=20250915T030400Z
+ARG MACHINE_GUEST_TOOLS_VERSION=0.17.2
+ARG MACHINE_GUEST_TOOLS_SHA256SUM=c077573dbcf0cdc146adf14b480bfe454ca63aa4d3e8408c5487f550a5b77a41
 
 ################################################################################
 # riscv64 base stage
@@ -20,6 +21,14 @@ apt-get update --snapshot=${APT_UPDATE_SNAPSHOT}
 apt-get remove -y --purge ca-certificates
 apt-get autoremove -y --purge
 EOF
+
+ARG MACHINE_GUEST_TOOLS_VERSION
+ARG MACHINE_GUEST_TOOLS_SHA256SUM
+ADD --checksum=sha256:${MACHINE_GUEST_TOOLS_SHA256SUM} \
+  https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb \
+  /tmp/machine-guest-tools_riscv64.deb
+
+RUN apt-get install -y --no-install-recommends /tmp/machine-guest-tools_riscv64.deb
 
 ################################################################################
 # riscv64 builder stage
@@ -38,18 +47,6 @@ apt-get install -y --no-install-recommends \
 rm -rf /var/lib/apt/lists/*
 EOF
 
-ARG MACHINE_GUEST_TOOLS_VERSION
-ADD https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb  /tmp/machine-guest-tools_riscv64.deb
-
-RUN <<EOF
-set -e
-echo "4af9911a5a76738d526bfc2b5462cf96c9dee98ec8b23f3ca91ac4849d5761765f471b5e2e8779809bc4a26d2799f8e744622864fa549ada5941e21d999ff4be /tmp/machine-guest-tools_riscv64.deb" \
-  | sha512sum -c
-apt-get install -y --no-install-recommends \
-  /tmp/machine-guest-tools_riscv64.deb
-rm /tmp/machine-guest-tools_riscv64.deb
-EOF
-
 WORKDIR /opt/cartesi/dapp
 COPY . .
 RUN make
@@ -58,21 +55,13 @@ RUN make
 # runtime stage: produces final image that will be executed
 FROM base
 
-ARG MACHINE_GUEST_TOOLS_VERSION
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
 apt-get install -y --no-install-recommends \
   busybox-static
 
-cd /tmp
-busybox wget https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb
-echo "4af9911a5a76738d526bfc2b5462cf96c9dee98ec8b23f3ca91ac4849d5761765f471b5e2e8779809bc4a26d2799f8e744622864fa549ada5941e21d999ff4be /tmp/machine-guest-tools_riscv64.deb" \
-  | sha512sum -c
-apt-get install -y --no-install-recommends \
-  /tmp/machine-guest-tools_riscv64.deb
 rm /tmp/machine-guest-tools_riscv64.deb
-
 rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
 EOF
 

--- a/cpp/Dockerfile
+++ b/cpp/Dockerfile
@@ -14,8 +14,10 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -eu
 apt-get update
-apt-get install -y --no-install-recommends ca-certificates curl
+apt-get install -y --no-install-recommends ca-certificates
 apt-get update --snapshot=${APT_UPDATE_SNAPSHOT}
+apt-get remove -y --purge ca-certificates
+apt-get autoremove -y --purge
 EOF
 
 ################################################################################
@@ -29,6 +31,8 @@ apt-get install -y --no-install-recommends \
   autoconf \
   automake \
   build-essential \
+  ca-certificates \
+  curl \
   libtool
 rm -rf /var/lib/apt/lists/*
 EOF

--- a/cpp/Dockerfile
+++ b/cpp/Dockerfile
@@ -4,6 +4,8 @@
 # for the defined date, no matter when the image is built.
 ARG UBUNTU_TAG=noble-20250910
 ARG APT_UPDATE_SNAPSHOT=20250915T030400Z
+ARG MACHINE_GUEST_TOOLS_VERSION=0.17.2
+ARG MACHINE_GUEST_TOOLS_SHA256SUM=c077573dbcf0cdc146adf14b480bfe454ca63aa4d3e8408c5487f550a5b77a41
 
 ################################################################################
 # riscv64 base stage
@@ -45,21 +47,20 @@ RUN make
 # runtime stage: produces final image that will be executed
 FROM base
 
-ARG MACHINE_GUEST_TOOLS_VERSION=0.17.2
+ARG MACHINE_GUEST_TOOLS_VERSION
+ARG MACHINE_GUEST_TOOLS_SHA256SUM
+ADD --checksum=sha256:${MACHINE_GUEST_TOOLS_SHA256SUM} \
+  https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb \
+  /tmp/machine-guest-tools_riscv64.deb
+
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
 apt-get install -y --no-install-recommends \
-  busybox-static
-
-cd /tmp
-busybox wget https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb
-echo "4af9911a5a76738d526bfc2b5462cf96c9dee98ec8b23f3ca91ac4849d5761765f471b5e2e8779809bc4a26d2799f8e744622864fa549ada5941e21d999ff4be /tmp/machine-guest-tools_riscv64.deb" \
-  | sha512sum -c
-apt-get install -y --no-install-recommends \
+  busybox-static \
   /tmp/machine-guest-tools_riscv64.deb
-rm /tmp/machine-guest-tools_riscv64.deb
 
+rm /tmp/machine-guest-tools_riscv64.deb
 rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
 EOF
 

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -14,8 +14,10 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -eu
 apt-get update
-apt-get install -y --no-install-recommends ca-certificates curl
+apt-get install -y --no-install-recommends ca-certificates
 apt-get update --snapshot=${APT_UPDATE_SNAPSHOT}
+apt-get remove -y --purge ca-certificates
+apt-get autoremove -y --purge
 EOF
 
 ################################################################################
@@ -27,8 +29,10 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -eu
 apt-get update
-apt-get install -y --no-install-recommends ca-certificates curl
+apt-get install -y --no-install-recommends ca-certificates
 apt-get update --snapshot=${APT_UPDATE_SNAPSHOT}
+apt-get remove -y --purge ca-certificates
+apt-get autoremove -y --purge
 EOF
 
 ################################################################################
@@ -41,6 +45,7 @@ set -e
 apt-get install -y --no-install-recommends \
     build-essential \
     ca-certificates \
+    curl \
     g++-riscv64-linux-gnu
 EOF
 

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -4,6 +4,8 @@
 # for the defined date, no matter when the image is built.
 ARG UBUNTU_TAG=noble-20250910
 ARG APT_UPDATE_SNAPSHOT=20250915T030400Z
+ARG MACHINE_GUEST_TOOLS_VERSION=0.17.2
+ARG MACHINE_GUEST_TOOLS_SHA256SUM=c077573dbcf0cdc146adf14b480bfe454ca63aa4d3e8408c5487f550a5b77a41
 
 ################################################################################
 # riscv64 base stage
@@ -70,21 +72,20 @@ RUN make
 # runtime stage: produces final image that will be executed
 FROM base-riscv64
 
-ARG MACHINE_GUEST_TOOLS_VERSION=0.17.2
+ARG MACHINE_GUEST_TOOLS_VERSION
+ARG MACHINE_GUEST_TOOLS_SHA256SUM
+ADD --checksum=sha256:${MACHINE_GUEST_TOOLS_SHA256SUM} \
+  https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb \
+  /tmp/machine-guest-tools_riscv64.deb
+
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
 apt-get install -y --no-install-recommends \
-  busybox-static
-
-cd /tmp
-busybox wget https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb
-echo "4af9911a5a76738d526bfc2b5462cf96c9dee98ec8b23f3ca91ac4849d5761765f471b5e2e8779809bc4a26d2799f8e744622864fa549ada5941e21d999ff4be /tmp/machine-guest-tools_riscv64.deb" \
-  | sha512sum -c
-apt-get install -y --no-install-recommends \
+  busybox-static \
   /tmp/machine-guest-tools_riscv64.deb
-rm /tmp/machine-guest-tools_riscv64.deb
 
+rm /tmp/machine-guest-tools_riscv64.deb
 rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
 EOF
 

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -6,6 +6,7 @@ ARG UBUNTU_TAG=noble-20250910
 ARG APT_UPDATE_SNAPSHOT=20250915T030400Z
 ARG MACHINE_GUEST_TOOLS_VERSION=0.17.2
 ARG MACHINE_GUEST_TOOLS_SHA256SUM=c077573dbcf0cdc146adf14b480bfe454ca63aa4d3e8408c5487f550a5b77a41
+ARG GOVERSION=1.25.3
 
 ################################################################################
 # riscv64 base stage
@@ -51,7 +52,7 @@ apt-get install -y --no-install-recommends \
     g++-riscv64-linux-gnu
 EOF
 
-ARG GOVERSION=1.23.2
+ARG GOVERSION
 
 WORKDIR /opt/build
 

--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -1,4 +1,6 @@
 # syntax=docker.io/docker/dockerfile:1
+ARG MACHINE_GUEST_TOOLS_VERSION=0.17.2
+ARG MACHINE_GUEST_TOOLS_SHA256SUM=c077573dbcf0cdc146adf14b480bfe454ca63aa4d3e8408c5487f550a5b77a41
 
 # ################################################################################
 # Java build stage (host arch)
@@ -20,22 +22,21 @@ RUN ./gradlew --no-daemon shadowJar
 # # Runtime stage (Cartesi-compatible: linux/riscv64)
 FROM --platform=linux/riscv64 eclipse-temurin:21-jre
 
-ARG MACHINE_GUEST_TOOLS_VERSION=0.17.2
+ARG MACHINE_GUEST_TOOLS_VERSION
+ARG MACHINE_GUEST_TOOLS_SHA256SUM
+ADD --checksum=sha256:${MACHINE_GUEST_TOOLS_SHA256SUM} \
+  https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb \
+  /tmp/machine-guest-tools_riscv64.deb
+
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
 apt-get update
 apt-get install -y --no-install-recommends \
-  busybox-static
-
-cd /tmp
-busybox wget https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb
-echo "4af9911a5a76738d526bfc2b5462cf96c9dee98ec8b23f3ca91ac4849d5761765f471b5e2e8779809bc4a26d2799f8e744622864fa549ada5941e21d999ff4be /tmp/machine-guest-tools_riscv64.deb" \
-  | sha512sum -c
-apt-get install -y --no-install-recommends \
+  busybox-static \
   /tmp/machine-guest-tools_riscv64.deb
-rm /tmp/machine-guest-tools_riscv64.deb
 
+rm /tmp/machine-guest-tools_riscv64.deb
 rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
 EOF
 

--- a/javascript/Dockerfile
+++ b/javascript/Dockerfile
@@ -3,6 +3,8 @@
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
 ARG APT_UPDATE_SNAPSHOT=20250915T030400Z
+ARG MACHINE_GUEST_TOOLS_VERSION=0.17.2
+ARG MACHINE_GUEST_TOOLS_SHA256SUM=c077573dbcf0cdc146adf14b480bfe454ca63aa4d3e8408c5487f550a5b77a41
 
 ################################################################################
 # riscv64 base stage
@@ -42,22 +44,21 @@ RUN yarn build
 # performance when loading the Cartesi Machine.
 FROM base
 
-ARG MACHINE_GUEST_TOOLS_VERSION=0.17.2
+ARG MACHINE_GUEST_TOOLS_VERSION
+ARG MACHINE_GUEST_TOOLS_SHA256SUM
+ADD --checksum=sha256:${MACHINE_GUEST_TOOLS_SHA256SUM} \
+  https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb \
+  /tmp/machine-guest-tools_riscv64.deb
+
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
 apt-get update
 apt-get install -y --no-install-recommends \
-  busybox-static
-
-cd /tmp
-busybox wget https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb
-echo "4af9911a5a76738d526bfc2b5462cf96c9dee98ec8b23f3ca91ac4849d5761765f471b5e2e8779809bc4a26d2799f8e744622864fa549ada5941e21d999ff4be /tmp/machine-guest-tools_riscv64.deb" \
-  | sha512sum -c
-apt-get install -y --no-install-recommends \
+  busybox-static \
   /tmp/machine-guest-tools_riscv64.deb
-rm /tmp/machine-guest-tools_riscv64.deb
 
+rm /tmp/machine-guest-tools_riscv64.deb
 rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
 EOF
 

--- a/javascript/Dockerfile
+++ b/javascript/Dockerfile
@@ -13,8 +13,10 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -eu
 apt-get update
-apt-get install -y --no-install-recommends ca-certificates curl
+apt-get install -y --no-install-recommends ca-certificates
 apt-get update --snapshot=${APT_UPDATE_SNAPSHOT}
+apt-get remove -y --purge ca-certificates
+apt-get autoremove -y --purge
 EOF
 
 ################################################################################

--- a/lua/Dockerfile
+++ b/lua/Dockerfile
@@ -16,6 +16,8 @@ set -eu
 apt-get update
 apt-get install -y --no-install-recommends ca-certificates
 apt-get update --snapshot=${APT_UPDATE_SNAPSHOT}
+apt-get remove -y --purge ca-certificates
+apt-get autoremove -y --purge
 EOF
 
 ################################################################################

--- a/lua/Dockerfile
+++ b/lua/Dockerfile
@@ -4,6 +4,8 @@
 # for the defined date, no matter when the image is built.
 ARG UBUNTU_TAG=noble-20250910
 ARG APT_UPDATE_SNAPSHOT=20250915T030400Z
+ARG MACHINE_GUEST_TOOLS_VERSION=0.17.2
+ARG MACHINE_GUEST_TOOLS_SHA256SUM=c077573dbcf0cdc146adf14b480bfe454ca63aa4d3e8408c5487f550a5b77a41
 
 ################################################################################
 # riscv64 base stage
@@ -42,23 +44,22 @@ EOF
 # riscv64 final stage
 FROM base
 
-ARG MACHINE_GUEST_TOOLS_VERSION=0.17.2
+ARG MACHINE_GUEST_TOOLS_VERSION
+ARG MACHINE_GUEST_TOOLS_SHA256SUM
+ADD --checksum=sha256:${MACHINE_GUEST_TOOLS_SHA256SUM} \
+  https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb \
+  /tmp/machine-guest-tools_riscv64.deb
+
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
 apt-get install -y --no-install-recommends \
   busybox-static \
+  /tmp/machine-guest-tools_riscv64.deb \
   liblua5.4-dev \
   lua5.4
 
-cd /tmp
-busybox wget https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb
-echo "4af9911a5a76738d526bfc2b5462cf96c9dee98ec8b23f3ca91ac4849d5761765f471b5e2e8779809bc4a26d2799f8e744622864fa549ada5941e21d999ff4be /tmp/machine-guest-tools_riscv64.deb" \
-  | sha512sum -c
-apt-get install -y --no-install-recommends \
-  /tmp/machine-guest-tools_riscv64.deb
 rm /tmp/machine-guest-tools_riscv64.deb
-
 rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
 EOF
 

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -3,6 +3,8 @@
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
 ARG APT_UPDATE_SNAPSHOT=20250915T030400Z
+ARG MACHINE_GUEST_TOOLS_VERSION=0.17.2
+ARG MACHINE_GUEST_TOOLS_SHA256SUM=c077573dbcf0cdc146adf14b480bfe454ca63aa4d3e8408c5487f550a5b77a41
 
 ################################################################################
 # riscv64 base stage
@@ -27,21 +29,20 @@ EOF
 # performance when loading the Cartesi Machine.
 FROM base
 
-ARG MACHINE_GUEST_TOOLS_VERSION=0.17.2
+ARG MACHINE_GUEST_TOOLS_VERSION
+ARG MACHINE_GUEST_TOOLS_SHA256SUM
+ADD --checksum=sha256:${MACHINE_GUEST_TOOLS_SHA256SUM} \
+  https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb \
+  /tmp/machine-guest-tools_riscv64.deb
+
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
 apt-get install -y --no-install-recommends \
-  busybox-static
-
-cd /tmp
-busybox wget https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb
-echo "4af9911a5a76738d526bfc2b5462cf96c9dee98ec8b23f3ca91ac4849d5761765f471b5e2e8779809bc4a26d2799f8e744622864fa549ada5941e21d999ff4be /tmp/machine-guest-tools_riscv64.deb" \
-  | sha512sum -c
-apt-get install -y --no-install-recommends \
+  busybox-static \
   /tmp/machine-guest-tools_riscv64.deb
-rm /tmp/machine-guest-tools_riscv64.deb
 
+rm /tmp/machine-guest-tools_riscv64.deb
 rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
 EOF
 

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -13,8 +13,10 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -eu
 apt-get update
-apt-get install -y --no-install-recommends ca-certificates curl
+apt-get install -y --no-install-recommends ca-certificates
 apt-get update --snapshot=${APT_UPDATE_SNAPSHOT}
+apt-get remove -y --purge ca-certificates
+apt-get autoremove -y --purge
 EOF
 
 ################################################################################

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -4,6 +4,8 @@
 # for the defined date, no matter when the image is built.
 ARG UBUNTU_TAG=noble-20250910
 ARG APT_UPDATE_SNAPSHOT=20250915T030400Z
+ARG MACHINE_GUEST_TOOLS_VERSION=0.17.2
+ARG MACHINE_GUEST_TOOLS_SHA256SUM=c077573dbcf0cdc146adf14b480bfe454ca63aa4d3e8408c5487f550a5b77a41
 
 ################################################################################
 # riscv64 base stage
@@ -46,22 +48,21 @@ EOF
 ################################################################################
 # runtime stage: produces final image that will be executed
 FROM base
-ARG MACHINE_GUEST_TOOLS_VERSION=0.17.2
+ARG MACHINE_GUEST_TOOLS_VERSION
+ARG MACHINE_GUEST_TOOLS_SHA256SUM
+ADD --checksum=sha256:${MACHINE_GUEST_TOOLS_SHA256SUM} \
+  https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb \
+  /tmp/machine-guest-tools_riscv64.deb
+
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
 apt-get install -y --no-install-recommends \
   busybox-static \
+  /tmp/machine-guest-tools_riscv64.deb \
   ruby
 
-cd /tmp
-busybox wget https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb
-echo "4af9911a5a76738d526bfc2b5462cf96c9dee98ec8b23f3ca91ac4849d5761765f471b5e2e8779809bc4a26d2799f8e744622864fa549ada5941e21d999ff4be /tmp/machine-guest-tools_riscv64.deb" \
-  | sha512sum -c
-apt-get install -y --no-install-recommends \
-  /tmp/machine-guest-tools_riscv64.deb
 rm /tmp/machine-guest-tools_riscv64.deb
-
 rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
 EOF
 

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -14,8 +14,10 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -eu
 apt-get update
-apt-get install -y --no-install-recommends ca-certificates curl
+apt-get install -y --no-install-recommends ca-certificates
 apt-get update --snapshot=${APT_UPDATE_SNAPSHOT}
+apt-get remove -y --purge ca-certificates
+apt-get autoremove -y --purge
 EOF
 
 ################################################################################

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -4,6 +4,8 @@
 # for the defined date, no matter when the image is built.
 ARG UBUNTU_TAG=noble-20250910
 ARG APT_UPDATE_SNAPSHOT=20250915T030400Z
+ARG MACHINE_GUEST_TOOLS_VERSION=0.17.2
+ARG MACHINE_GUEST_TOOLS_SHA256SUM=c077573dbcf0cdc146adf14b480bfe454ca63aa4d3e8408c5487f550a5b77a41
 
 ################################################################################
 # riscv64 base stage
@@ -49,6 +51,7 @@ RUN <<EOF
 set -e
 apt-get install -y --no-install-recommends \
     build-essential \
+    curl \
     g++-riscv64-linux-gnu
 EOF
 
@@ -84,21 +87,20 @@ RUN cargo build --release
 # runtime stage: produces final image that will be executed
 FROM base-riscv64
 
-ARG MACHINE_GUEST_TOOLS_VERSION=0.17.2
+ARG MACHINE_GUEST_TOOLS_VERSION
+ARG MACHINE_GUEST_TOOLS_SHA256SUM
+ADD --checksum=sha256:${MACHINE_GUEST_TOOLS_SHA256SUM} \
+  https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb \
+  /tmp/machine-guest-tools_riscv64.deb
+
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
 apt-get install -y --no-install-recommends \
-    busybox-static
-
-cd /tmp
-busybox wget https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb
-echo "4af9911a5a76738d526bfc2b5462cf96c9dee98ec8b23f3ca91ac4849d5761765f471b5e2e8779809bc4a26d2799f8e744622864fa549ada5941e21d999ff4be /tmp/machine-guest-tools_riscv64.deb" \
-    | sha512sum -c
-apt-get install -y --no-install-recommends \
+    busybox-static \
     /tmp/machine-guest-tools_riscv64.deb
-rm /tmp/machine-guest-tools_riscv64.deb
 
+rm /tmp/machine-guest-tools_riscv64.deb
 rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
 EOF
 

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -6,6 +6,7 @@ ARG UBUNTU_TAG=noble-20250910
 ARG APT_UPDATE_SNAPSHOT=20250915T030400Z
 ARG MACHINE_GUEST_TOOLS_VERSION=0.17.2
 ARG MACHINE_GUEST_TOOLS_SHA256SUM=c077573dbcf0cdc146adf14b480bfe454ca63aa4d3e8408c5487f550a5b77a41
+ARG RUST_VERSION=1.90.0
 
 ################################################################################
 # riscv64 base stage
@@ -43,33 +44,34 @@ FROM base-cross AS cross-build-stage
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
-    PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.82.0
+    PATH=/usr/local/cargo/bin:$PATH
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
 apt-get install -y --no-install-recommends \
     build-essential \
+    ca-certificates \
     curl \
     g++-riscv64-linux-gnu
 EOF
 
+ARG RUST_VERSION
 RUN <<EOF
 set -eux
 dpkgArch="$(dpkg --print-architecture)"
 case "${dpkgArch##*-}" in \
-    amd64) rustArch='x86_64-unknown-linux-gnu'; rustupSha256='6aeece6993e902708983b209d04c0d1dbb14ebb405ddb87def578d41f920f56d' ;;
-    armhf) rustArch='armv7-unknown-linux-gnueabihf'; rustupSha256='3c4114923305f1cd3b96ce3454e9e549ad4aa7c07c03aec73d1a785e98388bed' ;;
-    arm64) rustArch='aarch64-unknown-linux-gnu'; rustupSha256='1cffbf51e63e634c746f741de50649bbbcbd9dbe1de363c9ecef64e278dba2b2' ;;
-    i386) rustArch='i686-unknown-linux-gnu'; rustupSha256='0a6bed6e9f21192a51f83977716466895706059afb880500ff1d0e751ada5237' ;;
+    amd64) rustArch='x86_64-unknown-linux-gnu'; rustupSha256='20a06e644b0d9bd2fbdbfd52d42540bdde820ea7df86e92e533c073da0cdd43c' ;;
+    armhf) rustArch='armv7-unknown-linux-gnueabihf'; rustupSha256='3b8daab6cc3135f2cd4b12919559e6adaee73a2fbefb830fadf0405c20231d61' ;;
+    arm64) rustArch='aarch64-unknown-linux-gnu'; rustupSha256='e3853c5a252fca15252d07cb23a1bdd9377a8c6f3efa01531109281ae47f841c' ;;
+    i386) rustArch='i686-unknown-linux-gnu'; rustupSha256='a5db2c4b29d23e9b318b955dd0337d6b52e93933608469085c924e0d05b1df1f' ;;
     *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;;
 esac
-url="https://static.rust-lang.org/rustup/archive/1.27.1/${rustArch}/rustup-init"
+url="https://static.rust-lang.org/rustup/archive/1.28.2/${rustArch}/rustup-init"
 curl -fsSL -O "$url"
 echo "${rustupSha256} *rustup-init" | sha256sum -c -
 chmod +x rustup-init
-./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch}
+./rustup-init -y --no-modify-path --profile minimal --default-toolchain ${RUST_VERSION} --default-host ${rustArch}
 rm rustup-init
 chmod -R a+w $RUSTUP_HOME $CARGO_HOME
 rustup --version

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -14,8 +14,10 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -eu
 apt-get update
-apt-get install -y --no-install-recommends ca-certificates curl
+apt-get install -y --no-install-recommends ca-certificates
 apt-get update --snapshot=${APT_UPDATE_SNAPSHOT}
+apt-get remove -y --purge ca-certificates
+apt-get autoremove -y --purge
 EOF
 
 ################################################################################
@@ -27,8 +29,10 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -eu
 apt-get update
-apt-get install -y --no-install-recommends ca-certificates curl
+apt-get install -y --no-install-recommends ca-certificates
 apt-get update --snapshot=${APT_UPDATE_SNAPSHOT}
+apt-get remove -y --purge ca-certificates
+apt-get autoremove -y --purge
 EOF
 
 ################################################################################

--- a/typescript/Dockerfile
+++ b/typescript/Dockerfile
@@ -3,6 +3,8 @@
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
 ARG APT_UPDATE_SNAPSHOT=20250915T030400Z
+ARG MACHINE_GUEST_TOOLS_VERSION=0.17.2
+ARG MACHINE_GUEST_TOOLS_SHA256SUM=c077573dbcf0cdc146adf14b480bfe454ca63aa4d3e8408c5487f550a5b77a41
 
 ################################################################################
 # riscv64 base stage
@@ -43,21 +45,20 @@ RUN yarn build
 # performance when loading the Cartesi Machine.
 FROM base
 
-ARG MACHINE_GUEST_TOOLS_VERSION=0.17.2
+ARG MACHINE_GUEST_TOOLS_VERSION
+ARG MACHINE_GUEST_TOOLS_SHA256SUM
+ADD --checksum=sha256:${MACHINE_GUEST_TOOLS_SHA256SUM} \
+  https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb \
+  /tmp/machine-guest-tools_riscv64.deb
+
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
 apt-get install -y --no-install-recommends \
-  busybox-static
-
-cd /tmp
-busybox wget https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb
-echo "4af9911a5a76738d526bfc2b5462cf96c9dee98ec8b23f3ca91ac4849d5761765f471b5e2e8779809bc4a26d2799f8e744622864fa549ada5941e21d999ff4be /tmp/machine-guest-tools_riscv64.deb" \
-  | sha512sum -c
-apt-get install -y --no-install-recommends \
+  busybox-static \
   /tmp/machine-guest-tools_riscv64.deb
-rm /tmp/machine-guest-tools_riscv64.deb
 
+rm /tmp/machine-guest-tools_riscv64.deb
 rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*
 EOF
 

--- a/typescript/Dockerfile
+++ b/typescript/Dockerfile
@@ -13,8 +13,10 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -eu
 apt-get update
-apt-get install -y --no-install-recommends ca-certificates curl
+apt-get install -y --no-install-recommends ca-certificates
 apt-get update --snapshot=${APT_UPDATE_SNAPSHOT}
+apt-get remove -y --purge ca-certificates
+apt-get autoremove -y --purge
 EOF
 
 ################################################################################


### PR DESCRIPTION
This pull request refactors all language Dockerfiles to improve security, reproducibility, and maintainability when installing the `machine-guest-tools` package. The changes standardize the way the package is downloaded and verified, moving from an in-container download and manual checksum verification to using Docker's `ADD` command with a SHA256 checksum. Additionally, the base image setup is streamlined by removing unnecessary dependencies after use.

Key changes:

**Security and reproducibility improvements:**

* Replaced in-container download and manual SHA512 checksum verification of `machine-guest-tools_riscv64.deb` with Docker's `ADD` command using a SHA256 checksum (`MACHINE_GUEST_TOOLS_SHA256SUM`). This ensures the downloaded file is verified before the build continues, reducing the risk of supply chain attacks. [[1]](diffhunk://#diff-4ce5ed242867709da66b465542643f5c4d0f37ca663a2543263c150a50dde2c0L2-R8) [[2]](diffhunk://#diff-3a4cf0094e745eb8d6156c50a7cc2f5c2bfeac389a9d1477f08320a0253891ceR7-R8) [[3]](diffhunk://#diff-e7c951435e49f58cbf8ae82360edd2a5fa60f2d369a01a37abac831d84cdc88dR7-R9) [[4]](diffhunk://#diff-2c3cd63eeda6d94e4ac3cc5a0493362bc97cd5f8fa694aea346ee2baf6cec5cbR2-R3) [[5]](diffhunk://#diff-f408b8e465d2b31e38dd296f380471a4e92cb16483dbd7a47fba9a6c18fbcb80R6-R7) [[6]](diffhunk://#diff-568a58385ab1ea65860e040bbfe1241f0cd1f28cdbb6884862844dfc89ede316R7-R8) [[7]](diffhunk://#diff-c4c9f41a561e18e28581e72d6e45de6aa258c28df8bcb6dad2241ac174d11185R6-R7) [[8]](diffhunk://#diff-4b62900532c579e3c7c952ed7e68a5614cfb8f35adf4640c4523c54fd3e29271R7-R8)

* Standardized the installation of `machine-guest-tools` across all Dockerfiles by removing the use of `busybox wget` and manual checksum verification, and instead using the `ADD` command with checksum and then installing the `.deb` package directly. [[1]](diffhunk://#diff-4ce5ed242867709da66b465542643f5c4d0f37ca663a2543263c150a50dde2c0L39-L50) [[2]](diffhunk://#diff-4ce5ed242867709da66b465542643f5c4d0f37ca663a2543263c150a50dde2c0L59-L73) [[3]](diffhunk://#diff-3a4cf0094e745eb8d6156c50a7cc2f5c2bfeac389a9d1477f08320a0253891ceL44-R63) [[4]](diffhunk://#diff-e7c951435e49f58cbf8ae82360edd2a5fa60f2d369a01a37abac831d84cdc88dL68-R89) [[5]](diffhunk://#diff-2c3cd63eeda6d94e4ac3cc5a0493362bc97cd5f8fa694aea346ee2baf6cec5cbL23-R39) [[6]](diffhunk://#diff-f408b8e465d2b31e38dd296f380471a4e92cb16483dbd7a47fba9a6c18fbcb80L43-R61) [[7]](diffhunk://#diff-568a58385ab1ea65860e040bbfe1241f0cd1f28cdbb6884862844dfc89ede316L43-L59) [[8]](diffhunk://#diff-c4c9f41a561e18e28581e72d6e45de6aa258c28df8bcb6dad2241ac174d11185L28-R45)

**Base image cleanup and dependency management:**

* Improved base image hygiene by removing `ca-certificates` after use in the base stage and running `apt-get autoremove` to clean up unnecessary packages, reducing image size and potential attack surface. [[1]](diffhunk://#diff-4ce5ed242867709da66b465542643f5c4d0f37ca663a2543263c150a50dde2c0L18-R32) [[2]](diffhunk://#diff-3a4cf0094e745eb8d6156c50a7cc2f5c2bfeac389a9d1477f08320a0253891ceL17-R22) [[3]](diffhunk://#diff-e7c951435e49f58cbf8ae82360edd2a5fa60f2d369a01a37abac831d84cdc88dL17-R23) [[4]](diffhunk://#diff-e7c951435e49f58cbf8ae82360edd2a5fa60f2d369a01a37abac831d84cdc88dL30-R38) [[5]](diffhunk://#diff-f408b8e465d2b31e38dd296f380471a4e92cb16483dbd7a47fba9a6c18fbcb80L16-R21) [[6]](diffhunk://#diff-568a58385ab1ea65860e040bbfe1241f0cd1f28cdbb6884862844dfc89ede316R21-R22) [[7]](diffhunk://#diff-c4c9f41a561e18e28581e72d6e45de6aa258c28df8bcb6dad2241ac174d11185L16-R21) [[8]](diffhunk://#diff-4b62900532c579e3c7c952ed7e68a5614cfb8f35adf4640c4523c54fd3e29271L17-R22)

* Ensured required build dependencies (`ca-certificates`, `curl`) are only installed where needed, improving clarity and minimizing the installed package set in each build stage. [[1]](diffhunk://#diff-3a4cf0094e745eb8d6156c50a7cc2f5c2bfeac389a9d1477f08320a0253891ceR36-R37) [[2]](diffhunk://#diff-e7c951435e49f58cbf8ae82360edd2a5fa60f2d369a01a37abac831d84cdc88dR51-R55)

**General maintainability:**

* Centralized version and checksum arguments (`MACHINE_GUEST_TOOLS_VERSION` and `MACHINE_GUEST_TOOLS_SHA256SUM`) at the top of each Dockerfile for easier updates in the future. [[1]](diffhunk://#diff-4ce5ed242867709da66b465542643f5c4d0f37ca663a2543263c150a50dde2c0L2-R8) [[2]](diffhunk://#diff-3a4cf0094e745eb8d6156c50a7cc2f5c2bfeac389a9d1477f08320a0253891ceR7-R8) [[3]](diffhunk://#diff-e7c951435e49f58cbf8ae82360edd2a5fa60f2d369a01a37abac831d84cdc88dR7-R9) [[4]](diffhunk://#diff-2c3cd63eeda6d94e4ac3cc5a0493362bc97cd5f8fa694aea346ee2baf6cec5cbR2-R3) [[5]](diffhunk://#diff-f408b8e465d2b31e38dd296f380471a4e92cb16483dbd7a47fba9a6c18fbcb80R6-R7) [[6]](diffhunk://#diff-568a58385ab1ea65860e040bbfe1241f0cd1f28cdbb6884862844dfc89ede316R7-R8) [[7]](diffhunk://#diff-c4c9f41a561e18e28581e72d6e45de6aa258c28df8bcb6dad2241ac174d11185R6-R7) [[8]](diffhunk://#diff-4b62900532c579e3c7c952ed7e68a5614cfb8f35adf4640c4523c54fd3e29271R7-R8)


---

Size Summary

| Rootfs | Before | After | Difference |
|--------|--------|-------|------------|
| cpp-low-level-rootfs | 73.9 MB | 67.7 MB | -6.2 MB |
| cpp-rootfs | 74.7 MB | 68.5 MB | -6.2 MB |
| go-rootfs | 82.1 MB | 76.5 MB | -5.6 MB |
| java-rootfs | 212 MB | 212 MB | 0 MB |
| javascript-rootfs | 161 MB | 155 MB | -6 MB |
| lua-rootfs | 92.9 MB | 91.6 MB | -1.3 MB |
| python-rootfs | 98.5 MB | 92.3 MB | -6.2 MB |
| ruby-rootfs | 103 MB | 98 MB | -5 MB |
| rust-rootfs | 76.2 MB | 70.1 MB | -6.1 MB |
| typescript-rootfs | 161 MB | 155 MB | -6 MB |

References:

- https://github.com/cartesi/application-templates/actions/runs/18786434516
- https://github.com/cartesi/application-templates/actions/runs/18696888008