### PR TITLE
chore/bump ubuntu baseimage to noble 20260610

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,10 +26,10 @@ jobs:
           - typescript
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: current
 
@@ -37,7 +37,7 @@ jobs:
         run: npm install -g @cartesi/cli@2.0.0-alpha.34
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
       - name: Check system requirements
         run: cartesi doctor
@@ -51,7 +51,7 @@ jobs:
         working-directory: ${{ matrix.template }}
 
       - name: Upload root.ext2 artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.template }}-rootfs
           path: |

--- a/cpp-low-level/Dockerfile
+++ b/cpp-low-level/Dockerfile
@@ -18,8 +18,6 @@ set -eu
 apt-get update
 apt-get install -y --no-install-recommends ca-certificates
 apt-get update --snapshot=${APT_UPDATE_SNAPSHOT}
-apt-get remove -y --purge ca-certificates
-apt-get autoremove -y --purge
 EOF
 
 ARG MACHINE_GUEST_TOOLS_VERSION
@@ -34,10 +32,11 @@ RUN apt-get install -y --no-install-recommends /tmp/machine-guest-tools_riscv64.
 # riscv64 builder stage
 FROM base AS builder
 
+ARG APT_UPDATE_SNAPSHOT
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
-set -e
-apt-get install -y --no-install-recommends \
+set -eu
+apt-get install -y --no-install-recommends --snapshot=${APT_UPDATE_SNAPSHOT} \
   autoconf \
   automake \
   build-essential \
@@ -55,11 +54,15 @@ RUN make
 # runtime stage: produces final image that will be executed
 FROM base
 
+ARG APT_UPDATE_SNAPSHOT
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
-set -e
-apt-get install -y --no-install-recommends \
+set -eu
+apt-get install -y --no-install-recommends --snapshot=${APT_UPDATE_SNAPSHOT} \
   busybox-static
+
+apt-get remove -y --purge ca-certificates
+apt-get autoremove -y --purge
 
 rm /tmp/machine-guest-tools_riscv64.deb
 rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*

--- a/cpp-low-level/Dockerfile
+++ b/cpp-low-level/Dockerfile
@@ -2,8 +2,8 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG UBUNTU_TAG=noble-20260410
-ARG APT_UPDATE_SNAPSHOT=20260415T030400Z
+ARG UBUNTU_TAG=noble-20260610
+ARG APT_UPDATE_SNAPSHOT=20260701T030400Z
 ARG MACHINE_GUEST_TOOLS_VERSION=0.17.2
 ARG MACHINE_GUEST_TOOLS_SHA256SUM=c077573dbcf0cdc146adf14b480bfe454ca63aa4d3e8408c5487f550a5b77a41
 

--- a/cpp/Dockerfile
+++ b/cpp/Dockerfile
@@ -2,8 +2,8 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG UBUNTU_TAG=noble-20260410
-ARG APT_UPDATE_SNAPSHOT=20260415T030400Z
+ARG UBUNTU_TAG=noble-20260610
+ARG APT_UPDATE_SNAPSHOT=20260701T030400Z
 ARG MACHINE_GUEST_TOOLS_VERSION=0.17.2
 ARG MACHINE_GUEST_TOOLS_SHA256SUM=c077573dbcf0cdc146adf14b480bfe454ca63aa4d3e8408c5487f550a5b77a41
 

--- a/cpp/Dockerfile
+++ b/cpp/Dockerfile
@@ -18,18 +18,17 @@ set -eu
 apt-get update
 apt-get install -y --no-install-recommends ca-certificates
 apt-get update --snapshot=${APT_UPDATE_SNAPSHOT}
-apt-get remove -y --purge ca-certificates
-apt-get autoremove -y --purge
 EOF
 
 ################################################################################
 # riscv64 builder stage
 FROM base AS builder
 
+ARG APT_UPDATE_SNAPSHOT
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
-set -e
-apt-get install -y --no-install-recommends \
+set -eu
+apt-get install -y --no-install-recommends --snapshot=${APT_UPDATE_SNAPSHOT} \
   autoconf \
   automake \
   build-essential \
@@ -53,12 +52,16 @@ ADD --checksum=sha256:${MACHINE_GUEST_TOOLS_SHA256SUM} \
   https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb \
   /tmp/machine-guest-tools_riscv64.deb
 
+ARG APT_UPDATE_SNAPSHOT
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
-set -e
-apt-get install -y --no-install-recommends \
+set -eu
+apt-get install -y --no-install-recommends --snapshot=${APT_UPDATE_SNAPSHOT} \
   busybox-static \
   /tmp/machine-guest-tools_riscv64.deb
+
+apt-get remove -y --purge ca-certificates
+apt-get autoremove -y --purge
 
 rm /tmp/machine-guest-tools_riscv64.deb
 rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -19,8 +19,6 @@ set -eu
 apt-get update
 apt-get install -y --no-install-recommends ca-certificates
 apt-get update --snapshot=${APT_UPDATE_SNAPSHOT}
-apt-get remove -y --purge ca-certificates
-apt-get autoremove -y --purge
 EOF
 
 ################################################################################
@@ -34,18 +32,17 @@ set -eu
 apt-get update
 apt-get install -y --no-install-recommends ca-certificates
 apt-get update --snapshot=${APT_UPDATE_SNAPSHOT}
-apt-get remove -y --purge ca-certificates
-apt-get autoremove -y --purge
 EOF
 
 ################################################################################
 # cross build stage
 FROM base-cross AS cross-build-stage
 
+ARG APT_UPDATE_SNAPSHOT
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
-set -e
-apt-get install -y --no-install-recommends \
+set -eu
+apt-get install -y --no-install-recommends --snapshot=${APT_UPDATE_SNAPSHOT} \
     build-essential \
     ca-certificates \
     curl \
@@ -79,12 +76,16 @@ ADD --checksum=sha256:${MACHINE_GUEST_TOOLS_SHA256SUM} \
   https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb \
   /tmp/machine-guest-tools_riscv64.deb
 
+ARG APT_UPDATE_SNAPSHOT
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
-set -e
-apt-get install -y --no-install-recommends \
+set -eu
+apt-get install -y --no-install-recommends --snapshot=${APT_UPDATE_SNAPSHOT} \
   busybox-static \
   /tmp/machine-guest-tools_riscv64.deb
+
+apt-get remove -y --purge ca-certificates
+apt-get autoremove -y --purge
 
 rm /tmp/machine-guest-tools_riscv64.deb
 rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -2,8 +2,8 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG UBUNTU_TAG=noble-20260410
-ARG APT_UPDATE_SNAPSHOT=20260415T030400Z
+ARG UBUNTU_TAG=noble-20260610
+ARG APT_UPDATE_SNAPSHOT=20260701T030400Z
 ARG MACHINE_GUEST_TOOLS_VERSION=0.17.2
 ARG MACHINE_GUEST_TOOLS_SHA256SUM=c077573dbcf0cdc146adf14b480bfe454ca63aa4d3e8408c5487f550a5b77a41
 ARG GOVERSION=1.25.3

--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -4,7 +4,7 @@ ARG MACHINE_GUEST_TOOLS_SHA256SUM=c077573dbcf0cdc146adf14b480bfe454ca63aa4d3e840
 
 # ################################################################################
 # Java build stage (host arch)
-FROM eclipse-temurin:21-jdk AS build
+FROM --platform=$BUILDPLATFORM eclipse-temurin:21-jdk-noble AS build
 
 WORKDIR /app
 
@@ -20,7 +20,7 @@ RUN ./gradlew --no-daemon shadowJar
 
 # ################################################################################
 # # Runtime stage (Cartesi-compatible: linux/riscv64)
-FROM --platform=linux/riscv64 eclipse-temurin:21-jre
+FROM --platform=linux/riscv64 eclipse-temurin:21-jre-noble
 
 ARG MACHINE_GUEST_TOOLS_VERSION
 ARG MACHINE_GUEST_TOOLS_SHA256SUM

--- a/javascript/Dockerfile
+++ b/javascript/Dockerfile
@@ -2,7 +2,7 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG APT_UPDATE_SNAPSHOT=20260415T030400Z
+ARG APT_UPDATE_SNAPSHOT=20260701T030400Z
 ARG MACHINE_GUEST_TOOLS_VERSION=0.17.2
 ARG MACHINE_GUEST_TOOLS_SHA256SUM=c077573dbcf0cdc146adf14b480bfe454ca63aa4d3e8408c5487f550a5b77a41
 

--- a/javascript/Dockerfile
+++ b/javascript/Dockerfile
@@ -17,8 +17,6 @@ set -eu
 apt-get update
 apt-get install -y --no-install-recommends ca-certificates
 apt-get update --snapshot=${APT_UPDATE_SNAPSHOT}
-apt-get remove -y --purge ca-certificates
-apt-get autoremove -y --purge
 EOF
 
 ################################################################################
@@ -50,13 +48,16 @@ ADD --checksum=sha256:${MACHINE_GUEST_TOOLS_SHA256SUM} \
   https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb \
   /tmp/machine-guest-tools_riscv64.deb
 
+ARG APT_UPDATE_SNAPSHOT
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
-set -e
-apt-get update
-apt-get install -y --no-install-recommends \
+set -eu
+apt-get install -y --no-install-recommends --snapshot=${APT_UPDATE_SNAPSHOT} \
   busybox-static \
   /tmp/machine-guest-tools_riscv64.deb
+
+apt-get remove -y --purge ca-certificates
+apt-get autoremove -y --purge
 
 rm /tmp/machine-guest-tools_riscv64.deb
 rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*

--- a/lua/Dockerfile
+++ b/lua/Dockerfile
@@ -2,8 +2,8 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG UBUNTU_TAG=noble-20260410
-ARG APT_UPDATE_SNAPSHOT=20260415T030400Z
+ARG UBUNTU_TAG=noble-20260610
+ARG APT_UPDATE_SNAPSHOT=20260701T030400Z
 ARG MACHINE_GUEST_TOOLS_VERSION=0.17.2
 ARG MACHINE_GUEST_TOOLS_SHA256SUM=c077573dbcf0cdc146adf14b480bfe454ca63aa4d3e8408c5487f550a5b77a41
 

--- a/lua/Dockerfile
+++ b/lua/Dockerfile
@@ -18,18 +18,17 @@ set -eu
 apt-get update
 apt-get install -y --no-install-recommends ca-certificates
 apt-get update --snapshot=${APT_UPDATE_SNAPSHOT}
-apt-get remove -y --purge ca-certificates
-apt-get autoremove -y --purge
 EOF
 
 ################################################################################
 # riscv64 builder stage
 FROM base AS builder
 
+ARG APT_UPDATE_SNAPSHOT
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
-set -e
-apt-get install -y --no-install-recommends \
+set -eu
+apt-get install -y --no-install-recommends --snapshot=${APT_UPDATE_SNAPSHOT} \
   build-essential \
   liblua5.4-dev \
   lua5.4 \
@@ -50,14 +49,18 @@ ADD --checksum=sha256:${MACHINE_GUEST_TOOLS_SHA256SUM} \
   https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb \
   /tmp/machine-guest-tools_riscv64.deb
 
+  ARG APT_UPDATE_SNAPSHOT
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
-set -e
-apt-get install -y --no-install-recommends \
+set -eu
+apt-get install -y --no-install-recommends --snapshot=${APT_UPDATE_SNAPSHOT} \
   busybox-static \
   /tmp/machine-guest-tools_riscv64.deb \
   liblua5.4-dev \
   lua5.4
+
+apt-get remove -y --purge ca-certificates
+apt-get autoremove -y --purge
 
 rm /tmp/machine-guest-tools_riscv64.deb
 rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -2,7 +2,7 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG APT_UPDATE_SNAPSHOT=20260415T030400Z
+ARG APT_UPDATE_SNAPSHOT=20260701T030400Z
 ARG MACHINE_GUEST_TOOLS_VERSION=0.17.2
 ARG MACHINE_GUEST_TOOLS_SHA256SUM=c077573dbcf0cdc146adf14b480bfe454ca63aa4d3e8408c5487f550a5b77a41
 

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -17,8 +17,6 @@ set -eu
 apt-get update
 apt-get install -y --no-install-recommends ca-certificates
 apt-get update --snapshot=${APT_UPDATE_SNAPSHOT}
-apt-get remove -y --purge ca-certificates
-apt-get autoremove -y --purge
 EOF
 
 ################################################################################
@@ -35,12 +33,16 @@ ADD --checksum=sha256:${MACHINE_GUEST_TOOLS_SHA256SUM} \
   https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb \
   /tmp/machine-guest-tools_riscv64.deb
 
+ARG APT_UPDATE_SNAPSHOT
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
-set -e
-apt-get install -y --no-install-recommends \
+set -eu
+apt-get install -y --no-install-recommends --snapshot=${APT_UPDATE_SNAPSHOT} \
   busybox-static \
   /tmp/machine-guest-tools_riscv64.deb
+
+apt-get remove -y --purge ca-certificates
+apt-get autoremove -y --purge
 
 rm /tmp/machine-guest-tools_riscv64.deb
 rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -2,8 +2,8 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG UBUNTU_TAG=noble-20260410
-ARG APT_UPDATE_SNAPSHOT=20260415T030400Z
+ARG UBUNTU_TAG=noble-20260610
+ARG APT_UPDATE_SNAPSHOT=20260701T030400Z
 ARG MACHINE_GUEST_TOOLS_VERSION=0.17.2
 ARG MACHINE_GUEST_TOOLS_SHA256SUM=c077573dbcf0cdc146adf14b480bfe454ca63aa4d3e8408c5487f550a5b77a41
 

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -18,18 +18,17 @@ set -eu
 apt-get update
 apt-get install -y --no-install-recommends ca-certificates
 apt-get update --snapshot=${APT_UPDATE_SNAPSHOT}
-apt-get remove -y --purge ca-certificates
-apt-get autoremove -y --purge
 EOF
 
 ################################################################################
 # riscv64 builder stage
 FROM base AS builder
 
+ARG APT_UPDATE_SNAPSHOT
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
-set -e
-apt-get install -y --no-install-recommends \
+set -eu
+apt-get install -y --no-install-recommends --snapshot=${APT_UPDATE_SNAPSHOT} \
   build-essential \
   ruby-dev \
   ruby
@@ -54,10 +53,11 @@ ADD --checksum=sha256:${MACHINE_GUEST_TOOLS_SHA256SUM} \
   https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb \
   /tmp/machine-guest-tools_riscv64.deb
 
+ARG APT_UPDATE_SNAPSHOT
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
-set -e
-apt-get install -y --no-install-recommends \
+set -eu
+apt-get install -y --no-install-recommends --snapshot=${APT_UPDATE_SNAPSHOT} \
   busybox-static \
   /tmp/machine-guest-tools_riscv64.deb \
   ruby

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -19,8 +19,6 @@ set -eu
 apt-get update
 apt-get install -y --no-install-recommends ca-certificates
 apt-get update --snapshot=${APT_UPDATE_SNAPSHOT}
-apt-get remove -y --purge ca-certificates
-apt-get autoremove -y --purge
 EOF
 
 ################################################################################
@@ -34,8 +32,6 @@ set -eu
 apt-get update
 apt-get install -y --no-install-recommends ca-certificates
 apt-get update --snapshot=${APT_UPDATE_SNAPSHOT}
-apt-get remove -y --purge ca-certificates
-apt-get autoremove -y --purge
 EOF
 
 ################################################################################
@@ -46,10 +42,11 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH
 
+ARG APT_UPDATE_SNAPSHOT
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
-set -e
-apt-get install -y --no-install-recommends \
+set -eu
+apt-get install -y --no-install-recommends --snapshot=${APT_UPDATE_SNAPSHOT} \
     build-essential \
     ca-certificates \
     curl \
@@ -95,12 +92,16 @@ ADD --checksum=sha256:${MACHINE_GUEST_TOOLS_SHA256SUM} \
   https://github.com/cartesi/machine-guest-tools/releases/download/v${MACHINE_GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb \
   /tmp/machine-guest-tools_riscv64.deb
 
+ARG APT_UPDATE_SNAPSHOT
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
-set -e
-apt-get install -y --no-install-recommends \
+set -eu
+apt-get install -y --no-install-recommends --snapshot=${APT_UPDATE_SNAPSHOT} \
     busybox-static \
     /tmp/machine-guest-tools_riscv64.deb
+
+apt-get remove -y --purge ca-certificates
+apt-get autoremove -y --purge
 
 rm /tmp/machine-guest-tools_riscv64.deb
 rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -2,8 +2,8 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG UBUNTU_TAG=noble-20260410
-ARG APT_UPDATE_SNAPSHOT=20260415T030400Z
+ARG UBUNTU_TAG=noble-20260610
+ARG APT_UPDATE_SNAPSHOT=20260701T030400Z
 ARG MACHINE_GUEST_TOOLS_VERSION=0.17.2
 ARG MACHINE_GUEST_TOOLS_SHA256SUM=c077573dbcf0cdc146adf14b480bfe454ca63aa4d3e8408c5487f550a5b77a41
 ARG RUST_VERSION=1.90.0

--- a/typescript/Dockerfile
+++ b/typescript/Dockerfile
@@ -2,7 +2,7 @@
 
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
-ARG APT_UPDATE_SNAPSHOT=20260415T030400Z
+ARG APT_UPDATE_SNAPSHOT=20260701T030400Z
 ARG MACHINE_GUEST_TOOLS_VERSION=0.17.2
 ARG MACHINE_GUEST_TOOLS_SHA256SUM=c077573dbcf0cdc146adf14b480bfe454ca63aa4d3e8408c5487f550a5b77a41
 

--- a/typescript/Dockerfile
+++ b/typescript/Dockerfile
@@ -17,8 +17,6 @@ set -eu
 apt-get update
 apt-get install -y --no-install-recommends ca-certificates
 apt-get update --snapshot=${APT_UPDATE_SNAPSHOT}
-apt-get remove -y --purge ca-certificates
-apt-get autoremove -y --purge
 EOF
 
 ################################################################################
@@ -53,10 +51,13 @@ ADD --checksum=sha256:${MACHINE_GUEST_TOOLS_SHA256SUM} \
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
-set -e
-apt-get install -y --no-install-recommends \
+set -eu
+apt-get install -y --no-install-recommends --snapshot=${APT_UPDATE_SNAPSHOT} \
   busybox-static \
   /tmp/machine-guest-tools_riscv64.deb
+
+apt-get remove -y --purge ca-certificates
+apt-get autoremove -y --purge
 
 rm /tmp/machine-guest-tools_riscv64.deb
 rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/*


### PR DESCRIPTION
- **fix(java): update container image tag and use**
- **chore(ci): bump and lock GH Actions**
- **chore: bump ubuntu baseimage to noble-20260610**
- **fix: use APT snapshot correctly to ensure reproducible build**

Inspired by this commit https://github.com/cartesi/honeypot/commit/589a9c1a26522904f79df4955caff69537d38b13